### PR TITLE
Print forge output to stderr

### DIFF
--- a/goerli-devnet/2023-06-22-test-nested-safe/sign-l1-approve.sh
+++ b/goerli-devnet/2023-06-22-test-nested-safe/sign-l1-approve.sh
@@ -5,7 +5,7 @@ source ../.env
 source .env
 source .env.local
 
-payload=$(forge script --via-ir --rpc-url ${L1_RPC_URL} TestNestedSafeL1 --sig "signApproval(address)" ${SIGNER_SAFE_1_L1} | grep -A1 vvvvvvvv | grep -v vvvvvvvv)
+payload=$(forge script --via-ir --rpc-url ${L1_RPC_URL} TestNestedSafeL1 --sig "signApproval(address)" ${SIGNER_SAFE_1_L1} | tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv)
 cd lib/base-contracts
 echo "${payload}" | go run ./cmd/sign --private-key ${PRIVATE_KEY}
 

--- a/goerli-devnet/2023-06-22-test-nested-safe/sign-l1.sh
+++ b/goerli-devnet/2023-06-22-test-nested-safe/sign-l1.sh
@@ -5,7 +5,7 @@ source ../.env
 source .env
 source .env.local
 
-payload=$(forge script --via-ir --rpc-url ${L1_RPC_URL} TestNestedSafeL1 --sig "signTransaction(address)" ${SIGNER_SAFE_2_L1} | grep -A1 vvvvvvvv | grep -v vvvvvvvv)
+payload=$(forge script --via-ir --rpc-url ${L1_RPC_URL} TestNestedSafeL1 --sig "signTransaction(address)" ${SIGNER_SAFE_2_L1} | tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv)
 cd lib/base-contracts
 echo "${payload}" | go run ./cmd/sign --private-key ${PRIVATE_KEY}
 

--- a/goerli-devnet/2023-06-22-test-nested-safe/sign-l2-approve.sh
+++ b/goerli-devnet/2023-06-22-test-nested-safe/sign-l2-approve.sh
@@ -5,6 +5,6 @@ source ../.env
 source .env
 source .env.local
 
-payload=$(forge script --via-ir --rpc-url ${L2_RPC_URL} TestNestedSafeL2 --sig "signApproval(address)" ${SIGNER_SAFE_1_L2} | grep -A1 vvvvvvvv | grep -v vvvvvvvv)
+payload=$(forge script --via-ir --rpc-url ${L2_RPC_URL} TestNestedSafeL2 --sig "signApproval(address)" ${SIGNER_SAFE_1_L2} | tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv)
 cd lib/base-contracts
 echo "${payload}" | go run ./cmd/sign --private-key ${PRIVATE_KEY}

--- a/goerli-devnet/2023-06-22-test-nested-safe/sign-l2.sh
+++ b/goerli-devnet/2023-06-22-test-nested-safe/sign-l2.sh
@@ -5,6 +5,6 @@ source ../.env
 source .env
 source .env.local
 
-payload=$(forge script --via-ir --rpc-url ${L2_RPC_URL} TestNestedSafeL2 --sig "signTransaction(address)" ${SIGNER_SAFE_2_L2} | grep -A1 vvvvvvvv | grep -v vvvvvvvv)
+payload=$(forge script --via-ir --rpc-url ${L2_RPC_URL} TestNestedSafeL2 --sig "signTransaction(address)" ${SIGNER_SAFE_2_L2} | tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv)
 cd lib/base-contracts
 echo "${payload}" | go run ./cmd/sign --private-key ${PRIVATE_KEY}

--- a/goerli-devnet/2023-06-23-transfer-l1-owner/Makefile
+++ b/goerli-devnet/2023-06-23-transfer-l1-owner/Makefile
@@ -8,7 +8,7 @@ include .env.local
 ##
 sign:
 	forge script --via-ir --rpc-url ${L1_RPC_URL} TransferL1Owner --sig "sign()" | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --private-key ${PRIVATE_KEY})
 
 run:

--- a/goerli-devnet/2023-06-23-transfer-l2-owner/Makefile
+++ b/goerli-devnet/2023-06-23-transfer-l2-owner/Makefile
@@ -8,7 +8,7 @@ include .env.local
 ##
 sign:
 	forge script --via-ir --rpc-url ${L2_RPC_URL} TransferL2Owner --sig "sign()" | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --private-key ${PRIVATE_KEY})
 
 run:

--- a/goerli-devnet/2023-06-26-use-challenger1of2/Makefile
+++ b/goerli-devnet/2023-06-26-use-challenger1of2/Makefile
@@ -27,7 +27,7 @@ endif
 step-1:
 	forge script --via-ir --rpc-url $(L1_RPC_URL) UpgradeL2OutputOracle \
 	--sig "signApproval(address)" $(SAFE_1_ADDR) | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --private-key $(PRIVATE_KEY))
 
 .PHONY: step-2
@@ -41,7 +41,7 @@ step-2:
 step-3:
 	forge script --via-ir --rpc-url $(L1_RPC_URL) UpgradeL2OutputOracle \
 	--sig "signTransaction(address)" $(SAFE_2_ADDR) | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --private-key $(PRIVATE_KEY))
 
 .PHONY: step-4

--- a/goerli-devnet/2023-06-27-test-l2-owner/Makefile
+++ b/goerli-devnet/2023-06-27-test-l2-owner/Makefile
@@ -14,7 +14,7 @@ get-impl-addr:
 sign:
 	forge script --via-ir --rpc-url $(L2_RPC_URL) TestNewOwner \
 	--sig "signApproval(address)" $(SAFE_1_ADDR) | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --private-key $(PRIVATE_KEY))
 
 .PHONY: approve

--- a/goerli-devnet/2023-06-28-safe-threshold/Makefile
+++ b/goerli-devnet/2023-06-28-safe-threshold/Makefile
@@ -9,7 +9,7 @@ include ../.env.local
 .PHONY: sign
 sign:
 	forge script --via-ir --rpc-url $(L2_RPC_URL) ChangeThreshold --sig "sign()" | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --private-key $(PRIVATE_KEY))
 
 .PHONY: run

--- a/goerli-devnet/2023-06-29-increase-finalization/Makefile
+++ b/goerli-devnet/2023-06-29-increase-finalization/Makefile
@@ -20,7 +20,7 @@ deploy-new-impl:
 step-1:
 	forge script --via-ir --rpc-url $(L1_RPC_URL) --sender $(SENDER) UpgradeL2OutputOracle \
 	--sig "signApproval(address)" $(SAFE_1_ADDR) | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --private-key $(PRIVATE_KEY))
 
 .PHONY: step-2
@@ -43,7 +43,7 @@ step-3:
 step-1-revert:
 	forge script --via-ir --rpc-url $(L1_RPC_URL) --sender $(SENDER) RevertL2OutputOracle \
 	--sig "signApproval(address)" $(SAFE_1_ADDR) | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --private-key $(PRIVATE_KEY))
 
 .PHONY: step-2-revert

--- a/goerli-devnet/2023-07-12-practicing-incident-response/Makefile
+++ b/goerli-devnet/2023-07-12-practicing-incident-response/Makefile
@@ -18,7 +18,7 @@ endif
 .PHONY: delete-outputs-sign
 delete-outputs-sign: deps
 	@forge script --via-ir --rpc-url $(L1_RPC_URL) DeleteL2Outputs --sig "sign()" | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --private-key $(PRIVATE_KEY))
 
 .PHONY: delete-outputs-run
@@ -33,7 +33,7 @@ delete-outputs-run: deps
 .PHONY: pause-portal-sign
 pause-portal-sign: deps
 	@forge script --via-ir --rpc-url $(L1_RPC_URL) PausePortal --sig "sign()" | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --private-key $(PRIVATE_KEY))
 
 .PHONY: pause-portal-run
@@ -48,7 +48,7 @@ pause-portal-run: deps
 .PHONY: unpause-portal-sign
 unpause-portal-sign: deps
 	@forge script --via-ir --rpc-url $(L1_RPC_URL) UnpausePortal --sig "sign()" | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --private-key $(PRIVATE_KEY))
 
 .PHONY: unpause-portal-run

--- a/goerli/2023-06-27-test-nested-safe/Makefile
+++ b/goerli/2023-06-27-test-nested-safe/Makefile
@@ -31,7 +31,7 @@ deploy-test-l2:
 # Step 1
 sign-approval-l1:
 	forge script --via-ir --rpc-url $(L1_RPC_URL) \
-	TestNestedSafeL1 --sig "signApproval(address)" ${SIGNER_SAFE_1_L1} | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	TestNestedSafeL1 --sig "signApproval(address)" ${SIGNER_SAFE_1_L1} | tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --ledger --hd-paths "m/44'/60'/$(LEDGER_ACCOUNT)'/0/0")
 
 # Step 2
@@ -43,7 +43,7 @@ approve-l1:
 # Step 3
 sign-l1:
 	forge script --via-ir --rpc-url ${L1_RPC_URL} \
-	TestNestedSafeL1 --sig "signTransaction(address)" ${SIGNER_SAFE_2_L1} | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	TestNestedSafeL1 --sig "signTransaction(address)" ${SIGNER_SAFE_2_L1} | tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --ledger --hd-paths "m/44'/60'/${LEDGER_ACCOUNT}'/0/0")
 
 # Step 4
@@ -58,7 +58,7 @@ execute-l1:
 # Step 1
 sign-approval-l2:
 	forge script --via-ir --rpc-url $(L2_RPC_URL) \
-	TestNestedSafeL2 --sig "signApproval(address)" ${SIGNER_SAFE_1_L2} | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	TestNestedSafeL2 --sig "signApproval(address)" ${SIGNER_SAFE_1_L2} | tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --ledger --hd-paths "m/44'/60'/$(LEDGER_ACCOUNT)'/0/0")
 
 # Step 2
@@ -70,7 +70,7 @@ approve-l2:
 # Step 3
 sign-l2:
 	forge script --via-ir --rpc-url ${L2_RPC_URL} \
-	TestNestedSafeL2 --sig "signTransaction(address)" ${SIGNER_SAFE_2_L2} | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	TestNestedSafeL2 --sig "signTransaction(address)" ${SIGNER_SAFE_2_L2} | tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --ledger --hd-paths "m/44'/60'/${LEDGER_ACCOUNT}'/0/0")
 
 # Step 4

--- a/goerli/2023-06-29-transfer-l1-owner/Makefile
+++ b/goerli/2023-06-29-transfer-l1-owner/Makefile
@@ -11,7 +11,7 @@ endif
 ##
 sign:
 	forge script --via-ir --rpc-url ${L1_RPC_URL} TransferL1Owner --sig "sign()" | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --ledger --hd-paths "m/44'/60'/$(LEDGER_ACCOUNT)'/0/0")
 
 run:

--- a/goerli/2023-06-29-transfer-l2-owner/Makefile
+++ b/goerli/2023-06-29-transfer-l2-owner/Makefile
@@ -11,7 +11,7 @@ endif
 ##
 sign:
 	forge script --via-ir --rpc-url ${L2_RPC_URL} TransferL2Owner --sig "sign()" | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --ledger --hd-paths "m/44'/60'/$(LEDGER_ACCOUNT)'/0/0")
 
 run:

--- a/goerli/2023-07-11-use-challenger1of2/Makefile
+++ b/goerli/2023-07-11-use-challenger1of2/Makefile
@@ -25,7 +25,7 @@ verify-new-impl:
 step-1:
 	forge script --via-ir --rpc-url $(L1_RPC_URL) UpgradeL2OutputOracle \
 	--sig "signApproval(address)" $(SAFE_1_ADDR) | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --ledger --hd-paths "m/44'/60'/$(LEDGER_ACCOUNT)'/0/0")
 
 .PHONY: step-2

--- a/localhost/2023-06-20-systemcfg-test/sign.sh
+++ b/localhost/2023-06-20-systemcfg-test/sign.sh
@@ -4,6 +4,6 @@ set -e
 source ../.env
 source .env
 
-payload=$(forge script --via-ir --rpc-url ${L1_RPC_URL} TransferSystemConfigOwner --sig "sign()" | grep -A1 vvvvvvvv | grep -v vvvvvvvv)
+payload=$(forge script --via-ir --rpc-url ${L1_RPC_URL} TransferSystemConfigOwner --sig "sign()" | tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv)
 cd lib/base-contracts
 echo "${payload}" | go run ./cmd/sign --private-key ${PRIVATE_KEY}

--- a/localhost/2023-06-27-use-challenger1of2/Makefile
+++ b/localhost/2023-06-27-use-challenger1of2/Makefile
@@ -14,7 +14,7 @@ deploy-new-impl:
 .PHONY: sign
 sign:
 	forge script --via-ir --rpc-url $(L1_RPC_URL) UpgradeL2OutputOracle --sig "sign()" | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --private-key $(PRIVATE_KEY))
 
 .PHONY: run

--- a/mainnet/2023-06-21-transfer-system-cfg-owner/sign.sh
+++ b/mainnet/2023-06-21-transfer-system-cfg-owner/sign.sh
@@ -4,6 +4,6 @@ set -e
 source ../.env
 source .env
 
-payload=$(forge script --via-ir --rpc-url ${L1_RPC_URL} TransferSystemConfigOwner --sig "sign()" | grep -A1 vvvvvvvv | grep -v vvvvvvvv)
+payload=$(forge script --via-ir --rpc-url ${L1_RPC_URL} TransferSystemConfigOwner --sig "sign()" | tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv)
 cd lib/base-contracts
 echo "${payload}" | go run ./cmd/sign --ledger --hd-path "m/44'/60'/${LEDGER_ACCOUNT}'/0/0"

--- a/setup-templates/template-generic/Makefile
+++ b/setup-templates/template-generic/Makefile
@@ -27,7 +27,7 @@ example-ledger:
 .PHONY: example-sign
 example-sign:
 	forge script --via-ir --rpc-url $(RPC_URL) $(script) --sig "sign()" | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --ledger --hd-paths "m/44'/60'/$(LEDGER_ACCOUNT)'/0/0")
 
 .PHONY: example-run
@@ -48,7 +48,7 @@ example-run:
 example-step-1:
 	forge script --via-ir --rpc-url $(RPC_URL) $(script) \
 	--sig "signApproval(address)" $(SAFE_1_ADDR) | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --ledger --hd-paths "m/44'/60'/$(LEDGER_ACCOUNT)'/0/0")
 
 .PHONY: example-step-2
@@ -62,7 +62,7 @@ example-step-2:
 example-step-3:
 	forge script --via-ir --rpc-url $(RPC_URL) $(script) \
 	--sig "signTransaction(address)" $(SAFE_2_ADDR) | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --ledger --hd-paths "m/44'/60'/$(LEDGER_ACCOUNT)'/0/0")
 
 .PHONY: example-step-4

--- a/setup-templates/template-incident/Makefile
+++ b/setup-templates/template-incident/Makefile
@@ -17,7 +17,7 @@ endif
 .PHONY: delete-outputs-sign
 delete-outputs-sign: deps
 	forge script --via-ir --rpc-url $(L1_RPC_URL) DeleteL2Outputs --sig "sign()" | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --ledger --hd-paths "m/44'/60'/$(LEDGER_ACCOUNT)'/0/0")
 
 .PHONY: delete-outputs-run
@@ -32,7 +32,7 @@ delete-outputs-run: deps
 .PHONY: pause-portal-sign
 pause-portal-sign: deps
 	forge script --via-ir --rpc-url $(L1_RPC_URL) PausePortal --sig "sign()" | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --ledger --hd-paths "m/44'/60'/$(LEDGER_ACCOUNT)'/0/0")
 
 .PHONY: pause-portal-run
@@ -47,7 +47,7 @@ pause-portal-run: deps
 .PHONY: unpause-portal-sign
 unpause-portal-sign: deps
 	forge script --via-ir --rpc-url $(L1_RPC_URL) UnpausePortal --sig "sign()" | \
-	grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
+	tee /dev/stderr | grep -A1 vvvvvvvv | grep -v vvvvvvvv | \
 	(cd lib/base-contracts && go run ./cmd/sign --ledger --hd-paths "m/44'/60'/$(LEDGER_ACCOUNT)'/0/0")
 
 .PHONY: unpause-portal-run


### PR DESCRIPTION
Previously the `grep` and pipe to `sign` swallows all output, which is confusing. This PR adds a `tee` which duplicates all the stdout to stderr for easier compilation progress and debugging.