### PR TITLE
[fix] Bump eip712signer version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ deps: install-eip712sign clean-lib forge-deps checkout-op-commit checkout-base-c
 
 .PHONY: install-eip712sign
 install-eip712sign:
-	go install github.com/base-org/eip712sign@v0.0.1
+	go install github.com/base-org/eip712sign@v0.0.2
 
 .PHONY: clean-lib
 clean-lib:


### PR DESCRIPTION
This passes in --sender by default which fixes an issue with tenderly simulations.
Can consider using a commit number in each directory rather than specifying it at the root level, but just making this fix for now.