### PR TITLE
(fix) Git clone SSH => HTTPS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ checkout-base-contracts-commit:
 	mkdir -p lib/base-contracts
 	cd lib/base-contracts; \
 	git init; \
-	git remote add origin git@github.com:base-org/contracts.git; \
+	git remote add origin https://github.com/base-org/contracts.git; \
 	git fetch --depth=1 origin $(BASE_CONTRACTS_COMMIT); \
 	git reset --hard FETCH_HEAD
 


### PR DESCRIPTION
### Description
Switch from ssh to https for cloning `base-org/contracts`. Ensures users don't need to have a ssh keypair [setup](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#cloning-with-ssh-urls).

### Script Output

```
cd lib/base-contracts; \
	git init; \
	git remote add origin https://github.com/base-org/contracts.git; \
	git fetch --depth=1 origin b22778cf4ac9d4307b3c7d439cbef9e672084785; \
	git reset --hard FETCH_HEAD
...
Unpacking objects: 100% (48/48), 33.22 KiB | 466.00 KiB/s, done.
```