### PR TITLE
[fix] Add go.mod files for deploys

### DIFF
--- a/goerli-devnet/2023-05-18-deploy/go.mod
+++ b/goerli-devnet/2023-05-18-deploy/go.mod
@@ -1,0 +1,10 @@
+module github.com/base-org/contract-deployments
+
+go 1.18
+
+require github.com/ethereum/go-ethereum v1.12.0
+
+require (
+	golang.org/x/crypto v0.1.0 // indirect
+	golang.org/x/sys v0.7.0 // indirect
+)

--- a/goerli-devnet/2023-05-18-deploy/go.sum
+++ b/goerli-devnet/2023-05-18-deploy/go.sum
@@ -1,0 +1,6 @@
+github.com/ethereum/go-ethereum v1.12.0 h1:bdnhLPtqETd4m3mS8BGMNvBTf36bO5bx/hxE2zljOa0=
+github.com/ethereum/go-ethereum v1.12.0/go.mod h1:/oo2X/dZLJjf2mJ6YT9wcWxa4nNJDBKDBU6sFIpx1Gs=
+golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
+golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/goerli/2023-01-31-deploy/go.mod
+++ b/goerli/2023-01-31-deploy/go.mod
@@ -1,0 +1,10 @@
+module github.com/base-org/contract-deployments
+
+go 1.18
+
+require github.com/ethereum/go-ethereum v1.12.0
+
+require (
+	golang.org/x/crypto v0.1.0 // indirect
+	golang.org/x/sys v0.7.0 // indirect
+)

--- a/goerli/2023-01-31-deploy/go.sum
+++ b/goerli/2023-01-31-deploy/go.sum
@@ -1,0 +1,6 @@
+github.com/ethereum/go-ethereum v1.12.0 h1:bdnhLPtqETd4m3mS8BGMNvBTf36bO5bx/hxE2zljOa0=
+github.com/ethereum/go-ethereum v1.12.0/go.mod h1:/oo2X/dZLJjf2mJ6YT9wcWxa4nNJDBKDBU6sFIpx1Gs=
+golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
+golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal-devnet/2023-05-25-deploy/go.mod
+++ b/internal-devnet/2023-05-25-deploy/go.mod
@@ -1,0 +1,10 @@
+module github.com/base-org/contract-deployments
+
+go 1.18
+
+require github.com/ethereum/go-ethereum v1.12.0
+
+require (
+	golang.org/x/crypto v0.1.0 // indirect
+	golang.org/x/sys v0.7.0 // indirect
+)

--- a/internal-devnet/2023-05-25-deploy/go.sum
+++ b/internal-devnet/2023-05-25-deploy/go.sum
@@ -1,0 +1,6 @@
+github.com/ethereum/go-ethereum v1.12.0 h1:bdnhLPtqETd4m3mS8BGMNvBTf36bO5bx/hxE2zljOa0=
+github.com/ethereum/go-ethereum v1.12.0/go.mod h1:/oo2X/dZLJjf2mJ6YT9wcWxa4nNJDBKDBU6sFIpx1Gs=
+golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
+golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal-testnet/2023-05-24-deploy/go.mod
+++ b/internal-testnet/2023-05-24-deploy/go.mod
@@ -1,0 +1,10 @@
+module github.com/base-org/contract-deployments
+
+go 1.18
+
+require github.com/ethereum/go-ethereum v1.12.0
+
+require (
+	golang.org/x/crypto v0.1.0 // indirect
+	golang.org/x/sys v0.7.0 // indirect
+)

--- a/internal-testnet/2023-05-24-deploy/go.sum
+++ b/internal-testnet/2023-05-24-deploy/go.sum
@@ -1,0 +1,6 @@
+github.com/ethereum/go-ethereum v1.12.0 h1:bdnhLPtqETd4m3mS8BGMNvBTf36bO5bx/hxE2zljOa0=
+github.com/ethereum/go-ethereum v1.12.0/go.mod h1:/oo2X/dZLJjf2mJ6YT9wcWxa4nNJDBKDBU6sFIpx1Gs=
+golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
+golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/localhost/2023-06-08-deploy/go.mod
+++ b/localhost/2023-06-08-deploy/go.mod
@@ -1,0 +1,10 @@
+module github.com/base-org/contract-deployments
+
+go 1.18
+
+require github.com/ethereum/go-ethereum v1.12.0
+
+require (
+	golang.org/x/crypto v0.1.0 // indirect
+	golang.org/x/sys v0.7.0 // indirect
+)

--- a/localhost/2023-06-08-deploy/go.sum
+++ b/localhost/2023-06-08-deploy/go.sum
@@ -1,0 +1,6 @@
+github.com/ethereum/go-ethereum v1.12.0 h1:bdnhLPtqETd4m3mS8BGMNvBTf36bO5bx/hxE2zljOa0=
+github.com/ethereum/go-ethereum v1.12.0/go.mod h1:/oo2X/dZLJjf2mJ6YT9wcWxa4nNJDBKDBU6sFIpx1Gs=
+golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
+golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/mainnet/2023-06-14-deploy/go.mod
+++ b/mainnet/2023-06-14-deploy/go.mod
@@ -1,0 +1,10 @@
+module github.com/base-org/contract-deployments
+
+go 1.18
+
+require github.com/ethereum/go-ethereum v1.12.0
+
+require (
+	golang.org/x/crypto v0.1.0 // indirect
+	golang.org/x/sys v0.7.0 // indirect
+)

--- a/mainnet/2023-06-14-deploy/go.sum
+++ b/mainnet/2023-06-14-deploy/go.sum
@@ -1,0 +1,6 @@
+github.com/ethereum/go-ethereum v1.12.0 h1:bdnhLPtqETd4m3mS8BGMNvBTf36bO5bx/hxE2zljOa0=
+github.com/ethereum/go-ethereum v1.12.0/go.mod h1:/oo2X/dZLJjf2mJ6YT9wcWxa4nNJDBKDBU6sFIpx1Gs=
+golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
+golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/setup-templates/template-deploy/go.mod
+++ b/setup-templates/template-deploy/go.mod
@@ -1,0 +1,10 @@
+module github.com/base-org/contract-deployments
+
+go 1.18
+
+require github.com/ethereum/go-ethereum v1.12.0
+
+require (
+	golang.org/x/crypto v0.1.0 // indirect
+	golang.org/x/sys v0.7.0 // indirect
+)

--- a/setup-templates/template-deploy/go.sum
+++ b/setup-templates/template-deploy/go.sum
@@ -1,0 +1,6 @@
+github.com/ethereum/go-ethereum v1.12.0 h1:bdnhLPtqETd4m3mS8BGMNvBTf36bO5bx/hxE2zljOa0=
+github.com/ethereum/go-ethereum v1.12.0/go.mod h1:/oo2X/dZLJjf2mJ6YT9wcWxa4nNJDBKDBU6sFIpx1Gs=
+golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
+golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
We used to have a top level go.mod file which was removed. Instead of adding it back, just added go.mod/go.sum files to each of the deploy directories to make them reproducible. This keeps the top level directory clean. Could consider pulling the deploy script out to a separate go module (similar to https://github.com/base-org/eip712sign), but since it may change over time, leaving it as is seems better.