### PR TITLE
Clone and install eip712sign from a local repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,12 +41,7 @@ deps: install-eip712sign clean-lib forge-deps checkout-op-commit checkout-base-c
 
 .PHONY: install-eip712sign
 install-eip712sign:
-	mkdir eip712sign-tmp
-	cd eip712sign-tmp
-	git clone git@github.com:base-org/eip712sign.git .
-	go install
-	cd ..
-	rm -rf eip712sign-tmp
+	go install github.com/base-org/eip712sign@v0.0.6
 
 .PHONY: clean-lib
 clean-lib:

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,12 @@ deps: install-eip712sign clean-lib forge-deps checkout-op-commit checkout-base-c
 
 .PHONY: install-eip712sign
 install-eip712sign:
-	go install github.com/base-org/eip712sign@v0.0.4
+	mkdir eip712sign-tmp
+	cd eip712sign-tmp
+	git clone git@github.com:base-org/eip712sign.git .
+	go install
+	cd ..
+	rm -rf eip712sign-tmp
 
 .PHONY: clean-lib
 clean-lib:


### PR DESCRIPTION
Per @mdehoog :
```
> we should temporarily remove the eip712sign installation from make deps given it's broken at the moment
> actually maybe better to fix it to do the local checkout, go install, and delete the local checkout. Once the upstream fix is merged we can switch it back to a remote go install
```

EDIT: since https://github.com/ethereum/go-ethereum/pull/28945 and subsequently https://github.com/base-org/eip712sign/pull/9 were merged, we were able to fix this by simply updating the version tag 
