### PR TITLE
Add Rollback template to script 

### DIFF
--- a/setup-templates/template-incident/script/RollbackPause.s.sol
+++ b/setup-templates/template-incident/script/RollbackPause.s.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import "@base-contracts/script/universal/MultisigBuilder.sol";
+import "@eth-optimism-bedrock/contracts/L1/OptimismPortal.sol";
+
+contract RollbackUnpausePortal is MultisigBuilder {
+    address constant internal OPTIMISM_PORTAL_PROXY = vm.envAddress("OPTIMISM_PORTAL_PROXY"); // TODO: define OPTIMISM_PORTAL_PROXY=xxx in the .env file
+    address constant internal GUARDIAN = vm.envAddress("GUARDIAN"); // TODO: define GUARDIAN=xxx in the .env file
+
+    function _postCheck() internal override view {
+        OptimismPortal optimismPortal = OptimismPortal(payable(OPTIMISM_PORTAL_PROXY));
+        require(optimismPortal.paused() == false, "UnpausePortal: Portal did not get unpaused");
+    }
+
+    function _buildCalls() internal override view returns (IMulticall3.Call3[] memory) {
+        IMulticall3.Call3[] memory calls = new IMulticall3.Call3[](1);
+
+        calls[0] = IMulticall3.Call3({
+            target: OPTIMISM_PORTAL_PROXY,
+            allowFailure: false,
+            callData: abi.encodeCall(
+                OptimismPortal.unpause, ()
+            )
+        });
+
+        return calls;
+    }
+
+    function _ownerSafe() internal override view returns (address) {
+        return GUARDIAN;
+    }
+
+    function _addOverrides(address _safe) internal override view returns (SimulationStateOverride memory) {
+        IGnosisSafe safe = IGnosisSafe(payable(_safe));
+        uint256 _nonce = _getNonce(safe);
+        return overrideSafeThresholdOwnerAndNonce(_safe, DEFAULT_SENDER, _nonce);
+    }
+
+    // This transaction expects that there will be a `Pause` transaction before this one
+    // but both txs will be signed ahead of time. Need to explicitly override the nonce to 
+    // ensure that the correct nonce is used in the sign, simulate and execution steps. 
+    function _getNonce(IGnosisSafe) internal override view returns (uint256 nonce) {
+        nonce = vm.envUint("ROLLBACK_NONCE");
+    }
+}


### PR DESCRIPTION
TLDR; this PR implements an example script which shows that a rollback transaction should explicitly set the nonce returned by `_getNonce()` using an .env var. Hopefully this template will help avoid issues seen below. 

Full context: 

In executing `mainnet/2024-03-05-pause-unpause-test` we ran into an issue wherein the signatures were being incorrectly ordered by the execution call. This was leading to reverts since the Safe requires that signatures are arranged in ascending order.

 The root cause was traced back to the fact that `_getNonce` was being overwritten by the following: 
```solidity
    function _getNonce(IGnosisSafe safe) internal override view returns (uint256 nonce) {
        uint256 _nonce = safe.nonce();
        console.log("Safe current nonce:", _nonce);
        console.log("Incrementing by 1 to account for planned `Pause` tx");
        return _nonce+1;
    }
```
This was fine for signing and simulating the transaction because these occurred before the preceding `Pause` transaction had been submitted. But when it came time to execute the transaction, this nonce increment was used in the execution context causing the `hash` used by `ecrecover` to differ from the correct `hash`. In turn, this lead to invalid addresses being returned which were then used to sort the signatures incorrectly.  