### PR TITLE
Typo Fixes in `Makefile` and `SetupNewProposer.s.sol`

### DIFF
--- a/mainnet/2023-07-26-transfer-owner-nested-safes/Makefile
+++ b/mainnet/2023-07-26-transfer-owner-nested-safes/Makefile
@@ -7,7 +7,7 @@ override LEDGER_ACCOUNT = 0
 endif
 
 ##
-# Commands for transfering ownership of L1 and L2 contracts to corresponding nested multisigs
+# Commands for transferring ownership of L1 and L2 contracts to corresponding nested multisigs
 # with CB and OP as signers
 ##
 

--- a/setup-templates/template-incident/script/SetupNewProposer.s.sol
+++ b/setup-templates/template-incident/script/SetupNewProposer.s.sol
@@ -22,7 +22,7 @@ contract SetupNewProposer is Script {
         console.log(oldProposer);
         console.log(NEW_PROPOSER);
 
-        // Deploy L2OutputOracle new implementation wiht the new submission interval
+        // Deploy L2OutputOracle new implementation with the new submission interval
         vm.broadcast(DEPLOYER);
         L2OutputOracle l2OutputOracleImpl = new L2OutputOracle({
             _submissionInterval: oldSubmissionInterval,


### PR DESCRIPTION
# Pull Request: Typo Fixes in `Makefile` and `SetupNewProposer.s.sol`

## Description
This pull request addresses multiple minor typos found in the `Makefile` and `SetupNewProposer.s.sol`. The changes ensure clarity and correctness in the documentation and code comments.

### Changes Made:
1. **Makefile**:
   - Corrected the spelling of **"transfering"** to **"transferring"**.
2. **SetupNewProposer.s.sol**:
   - Corrected the spelling of **"wiht"** to **"with"**.

## Files Modified
1. **mainnet/2023-07-26-transfer-owner-nested-safes/Makefile**:
   - **2 additions**
   - **2 deletions**
2. **setup-templates/template-incident/script/SetupNewProposer.s.sol**:
   - **2 additions**
   - **2 deletions**

### Before and After:

#### **Makefile**
- **Before**:
  > Commands for **transfering** ownership of L1 and L2 contracts to corresponding nested multisigs
- **After**:
  > Commands for **transferring** ownership of L1 and L2 contracts to corresponding nested multisigs

#### **SetupNewProposer.s.sol**
- **Before**:
  > Deploy L2OutputOracle new implementation **wiht** the new submission interval
- **After**:
  > Deploy L2OutputOracle new implementation **with** the new submission interval

## Author
- @teenager-ETH

## Review Checklist
- [ ] Verify the typos have been corrected.
- [ ] Confirm no additional changes were made beyond those described.
- [ ] Approve and merge if no further issues are found.

Thank you for reviewing!
