### PR TITLE
Remove Duplicate SystemDictatorImpl Serialization

### DIFF
--- a/goerli/2023-01-31-deploy/execute/RunDeployBedrock.s.sol
+++ b/goerli/2023-01-31-deploy/execute/RunDeployBedrock.s.sol
@@ -238,7 +238,6 @@ contract DeployBedrock is Script {
         vm.serializeAddress(json, "L1ERC721BridgeImpl", address(l1ERC721BridgeImpl));
         vm.serializeAddress(json, "SystemConfigImpl", address(systemConfigImpl));
         vm.serializeAddress(json, "SystemDictatorImpl", address(systemDictatorImpl));
-        vm.serializeAddress(json, "SystemDictatorImpl", address(systemDictatorImpl));
 
         vm.serializeUint(json, "BlockNumber", block.number);
         string memory finalJson = vm.serializeUint(json, "BlockTimestamp", block.timestamp);


### PR DESCRIPTION
Remove Duplicate SystemDictatorImpl Serialization

Changes Made in goerli/2023-01-31-deploy/execute/RunDeployBedrock.s.sol:
- Removed duplicate serialization of SystemDictatorImpl address