### PR TITLE
install current eip712sign package during make deps command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ deps: install-eip712sign clean-lib forge-deps checkout-op-commit checkout-base-c
 
 .PHONY: install-eip712sign
 install-eip712sign:
-	go install github.com/base-org/eip712sign@v0.0.6
+	go install github.com/base-org/eip712sign@v0.0.10
 
 .PHONY: clean-lib
 clean-lib:


### PR DESCRIPTION
The current version of [eip712sign](https://github.com/base-org/eip712sign) is `0.0.10`. Was running into errors with the old version while testing signing tasks.