### PR TITLE
fix: fix missing comma between `toHexString()` and closing brace

### DIFF
--- a/sepolia/2025-02-14-upgrade-fault-proofs/script/DeployDisputeGames.s.sol
+++ b/sepolia/2025-02-14-upgrade-fault-proofs/script/DeployDisputeGames.s.sol
@@ -70,7 +70,7 @@ contract DeployDisputeGames is Script {
                 "\",",
                 "\"permissionedDisputeGame\": \"",
                 pdg.toHexString(),
-                "\"" "}"
+                "\"}"
             )
         );
     }


### PR DESCRIPTION
i’ve fixed an issue where a comma was missing between the `toHexString()` method and the closing brace `}`.
this caused a syntax error, and after adding the missing comma, everything works as expected.