### PR TITLE
Fix foundry install target missing commit pin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+FOUNDRY_COMMIT ?= 3b1129b5bc43ba22a9bcf4e4323c5a9df0023140
+
 PROJECT_DIR = $(network)/$(shell date +'%Y-%m-%d')-$(task)
 GAS_INCREASE_DIR = $(network)/$(shell date +'%Y-%m-%d')-increase-gas-limit
 FAULT_PROOF_UPGRADE_DIR = $(network)/$(shell date +'%Y-%m-%d')-upgrade-fault-proofs


### PR DESCRIPTION
**Summary**

- Defaulted the FOUNDRY_COMMIT variable so make install-foundry always pins Foundry to the documented revision, preventing empty-argument failures when the variable is unset.

**Testing**

✅ make -n install-foundry