### PR TITLE
fix: update expected U17 task overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ checkout-base-contracts-commit:
 ##
 # Task Signer Tool
 ##
-SIGNER_TOOL_COMMIT=2ef56d9342285d7e62d0fe5564146bbb55312b1b
+SIGNER_TOOL_COMMIT=e45ae99d8bb414c7032fec0653978746fb8ac401
 SIGNER_TOOL_PATH=signer-tool
 
 .PHONY: checkout-signer-tool

--- a/mainnet/2025-11-21-u17-jovian-upgrade/Makefile
+++ b/mainnet/2025-11-21-u17-jovian-upgrade/Makefile
@@ -31,7 +31,7 @@ run-script-cb:
 	npm ci; \
 	bun run scripts/genValidationFile.ts --rpc-url $(RPC_URL) \
 	--workdir .. --forge-cmd 'forge script --rpc-url $(RPC_URL) \
-	$(SCRIPT_NAME) --sig "sign(address[])" "[$(CB_NESTED_SAFE_ADDR), $(CB_SIGNER_SAFE_ADDR)]" --sender 0x6CD3850756b7894774Ab715D136F9dD02837De50' --out ../validations/cb-signer.json;
+	$(SCRIPT_NAME) --sig "sign(address[])" "[$(CB_NESTED_SAFE_ADDR),$(CB_SIGNER_SAFE_ADDR)]" --sender 0x6CD3850756b7894774Ab715D136F9dD02837De50' --out ../validations/coinbase-signer.json;
 
 
 .PHONY: gen-validation-cb-sc
@@ -43,7 +43,7 @@ run-script-cb-sc:
 	npm ci; \
 	bun run scripts/genValidationFile.ts --rpc-url $(RPC_URL) \
 	--workdir .. --forge-cmd 'forge script --rpc-url $(RPC_URL) \
-	$(SCRIPT_NAME) --sig "sign(address[])" "[$(CB_SC_SAFE_ADDR), $(CB_SIGNER_SAFE_ADDR)]" --sender 0x5ff5C78ff194acc24C22DAaDdE4D639ebF18ACC6' --out ../validations/cb-sc-signer.json;
+	$(SCRIPT_NAME) --sig "sign(address[])" "[$(CB_SC_SAFE_ADDR),$(CB_SIGNER_SAFE_ADDR)]" --sender 0x5ff5C78ff194acc24C22DAaDdE4D639ebF18ACC6' --out ../validations/base-security-council-signer.json;
 
 .PHONY: gen-validation-op
 gen-validation-op: checkout-signer-tool run-script-op
@@ -54,7 +54,7 @@ run-script-op:
 	npm ci; \
 	bun run scripts/genValidationFile.ts --rpc-url $(RPC_URL) \
 	--workdir .. --forge-cmd 'forge script --rpc-url $(RPC_URL) \
-	$(SCRIPT_NAME) --sig "sign(address[])" "[$(OP_SIGNER_SAFE_ADDR)]" --sender 0x42d27eEA1AD6e22Af6284F609847CB3Cd56B9c64' --out ../validations/op-signer.json;
+	$(SCRIPT_NAME) --sig "sign(address[])" "[$(OP_SIGNER_SAFE_ADDR)]" --sender 0x42d27eEA1AD6e22Af6284F609847CB3Cd56B9c64' --out ../validations/optimism-signer.json;
 
 
 # CB

--- a/mainnet/2025-11-21-u17-jovian-upgrade/validations/base-security-council-signer.json
+++ b/mainnet/2025-11-21-u17-jovian-upgrade/validations/base-security-council-signer.json
@@ -15,12 +15,14 @@
         {
           "key": "0x0000000000000000000000000000000000000000000000000000000000000004",
           "value": "0x0000000000000000000000000000000000000000000000000000000000000001",
-          "description": "Override the threshold to 1 so the transaction simulation can occur."
+          "description": "Override the threshold to 1 so the transaction simulation can occur.",
+          "allowDifference": false
         },
         {
           "key": "0x806a47f0204113e9d747e5ebe5904a862f2ca1ccc48015282fa4914fa98931fa",
           "value": "0x0000000000000000000000000000000000000000000000000000000000000001",
-          "description": "Simulates an approval from msg.sender in order for the task simulation to succeed."
+          "description": "Simulates an approval from msg.sender in order for the task simulation to succeed.",
+          "allowDifference": false
         }
       ]
     },
@@ -31,18 +33,8 @@
         {
           "key": "0x0000000000000000000000000000000000000000000000000000000000000004",
           "value": "0x0000000000000000000000000000000000000000000000000000000000000001",
-          "description": "Override the threshold to 1 so the transaction simulation can occur."
-        }
-      ]
-    },
-    {
-      "name": "Superchain Config - Mainnet",
-      "address": "0x95703e0982140d16f8eba6d158fccede42f04a4c",
-      "overrides": [
-        {
-          "key": "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc",
-          "value": "0x000000000000000000000000b08cc720f511062537ca78bdb0ae691f04f5a957",
-          "description": "Override the SuperchainConfig implementation address so the version is the U17 expected version."
+          "description": "Override the threshold to 1 so the transaction simulation can occur.",
+          "allowDifference": false
         }
       ]
     },
@@ -53,7 +45,8 @@
         {
           "key": "0x0000000000000000000000000000000000000000000000000000000000000004",
           "value": "0x0000000000000000000000000000000000000000000000000000000000000001",
-          "description": "Override the threshold to 1 so the transaction simulation can occur."
+          "description": "Override the threshold to 1 so the transaction simulation can occur.",
+          "allowDifference": false
         }
       ]
     }

--- a/mainnet/2025-11-21-u17-jovian-upgrade/validations/coinbase-signer.json
+++ b/mainnet/2025-11-21-u17-jovian-upgrade/validations/coinbase-signer.json
@@ -15,18 +15,8 @@
         {
           "key": "0x0000000000000000000000000000000000000000000000000000000000000004",
           "value": "0x0000000000000000000000000000000000000000000000000000000000000001",
-          "description": "Override the threshold to 1 so the transaction simulation can occur."
-        }
-      ]
-    },
-    {
-      "name": "Superchain Config - Mainnet",
-      "address": "0x95703e0982140d16f8eba6d158fccede42f04a4c",
-      "overrides": [
-        {
-          "key": "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc",
-          "value": "0x000000000000000000000000b08cc720f511062537ca78bdb0ae691f04f5a957",
-          "description": "Override the SuperchainConfig implementation address so the version is the U17 expected version."
+          "description": "Override the threshold to 1 so the transaction simulation can occur.",
+          "allowDifference": false
         }
       ]
     },
@@ -37,7 +27,8 @@
         {
           "key": "0x0000000000000000000000000000000000000000000000000000000000000004",
           "value": "0x0000000000000000000000000000000000000000000000000000000000000001",
-          "description": "Override the threshold to 1 so the transaction simulation can occur."
+          "description": "Override the threshold to 1 so the transaction simulation can occur.",
+          "allowDifference": false
         }
       ]
     },
@@ -48,12 +39,14 @@
         {
           "key": "0x0000000000000000000000000000000000000000000000000000000000000004",
           "value": "0x0000000000000000000000000000000000000000000000000000000000000001",
-          "description": "Override the threshold to 1 so the transaction simulation can occur."
+          "description": "Override the threshold to 1 so the transaction simulation can occur.",
+          "allowDifference": false
         },
         {
           "key": "0x956f0b7b97716c3ae73ece58ee0bdd1334ca30481111f3e5a428de727da5d7a2",
           "value": "0x0000000000000000000000000000000000000000000000000000000000000001",
-          "description": "Simulates an approval from msg.sender in order for the task simulation to succeed."
+          "description": "Simulates an approval from msg.sender in order for the task simulation to succeed.",
+          "allowDifference": false
         }
       ]
     }

--- a/mainnet/2025-11-21-u17-jovian-upgrade/validations/optimism-signer.json
+++ b/mainnet/2025-11-21-u17-jovian-upgrade/validations/optimism-signer.json
@@ -15,18 +15,8 @@
         {
           "key": "0x0000000000000000000000000000000000000000000000000000000000000004",
           "value": "0x0000000000000000000000000000000000000000000000000000000000000001",
-          "description": "Override the threshold to 1 so the transaction simulation can occur."
-        }
-      ]
-    },
-    {
-      "name": "Superchain Config - Mainnet",
-      "address": "0x95703e0982140d16f8eba6d158fccede42f04a4c",
-      "overrides": [
-        {
-          "key": "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc",
-          "value": "0x000000000000000000000000b08cc720f511062537ca78bdb0ae691f04f5a957",
-          "description": "Override the SuperchainConfig implementation address so the version is the U17 expected version."
+          "description": "Override the threshold to 1 so the transaction simulation can occur.",
+          "allowDifference": false
         }
       ]
     },
@@ -37,12 +27,14 @@
         {
           "key": "0x0000000000000000000000000000000000000000000000000000000000000004",
           "value": "0x0000000000000000000000000000000000000000000000000000000000000001",
-          "description": "Override the threshold to 1 so the transaction simulation can occur."
+          "description": "Override the threshold to 1 so the transaction simulation can occur.",
+          "allowDifference": false
         },
         {
           "key": "0x0c3a0d2f6b87b30ec81565f13e420b1a13506a18c0f35bdf7dedb7457048668d",
           "value": "0x0000000000000000000000000000000000000000000000000000000000000001",
-          "description": "Simulates an approval from msg.sender in order for the task simulation to succeed."
+          "description": "Simulates an approval from msg.sender in order for the task simulation to succeed.",
+          "allowDifference": false
         }
       ]
     }


### PR DESCRIPTION
The expected task overrides are now incorrect since OP ran their upgrade and the tool is not recognizing that this should be ok. For now, re-generating the validation files is easiest. In the future, we should make sure the tool can recognize this edge case