### PR TITLE
fix(mainnet): recalculate DA scalar with blob target 10

### DIFF
--- a/mainnet/2025-12-08-increase-gas-and-elasticity-limit/.env
+++ b/mainnet/2025-12-08-increase-gas-and-elasticity-limit/.env
@@ -12,10 +12,10 @@ TO_ELASTICITY=6
 
 # Formula: da_footprint_gas_scalar = gas_limit / (elasticity * target_blob_count * 32,000)
 # Where target_blob_count = target number of blobs per L1 block
-# Example with gas_limit = 120,000,000, elasticity = 2, target_blob_count = 6:
-#   da_footprint_gas_scalar = 120,000,000 / (2 * 6 * 32,000) = 312.5 ≈ 312
+# Example with gas_limit = 375,000,000, elasticity = 6, target_blob_count = 10:
+#   da_footprint_gas_scalar = 375,000,000 / (6 * 10 * 32,000) = 195.3 ≈ 195
 FROM_DA_FOOTPRINT_GAS_SCALAR=312
-TO_DA_FOOTPRINT_GAS_SCALAR=325
+TO_DA_FOOTPRINT_GAS_SCALAR=195
 
 SENDER=0x1841CB3C2ce6870D0417844C817849da64E6e937
 

--- a/mainnet/2025-12-08-increase-gas-and-elasticity-limit/Makefile
+++ b/mainnet/2025-12-08-increase-gas-and-elasticity-limit/Makefile
@@ -14,6 +14,23 @@ endif
 RPC_URL = $(L1_RPC_URL)
 SCRIPT_NAME = IncreaseEip1559ElasticityAndIncreaseGasLimitScript
 
+# Calculate the DA footprint gas scalar based on the formula:
+# da_footprint_gas_scalar = gas_limit / (elasticity * target_blob_count * 32,000)
+# Uses TO_GAS_LIMIT and TO_ELASTICITY from .env
+.PHONY: da-scalar
+da-scalar:
+ifndef TARGET_BLOB_COUNT
+	$(error TARGET_BLOB_COUNT is not set. Usage: make da-scalar TARGET_BLOB_COUNT=<value>)
+endif
+ifeq ($(TO_GAS_LIMIT),TODO)
+	$(error TO_GAS_LIMIT is not set. Please set it in .env before running this command.)
+endif
+ifeq ($(TO_ELASTICITY),TODO)
+	$(error TO_ELASTICITY is not set. Please set it in .env before running this command.)
+endif
+	@echo "$(TO_GAS_LIMIT) / ($(TO_ELASTICITY) * $(TARGET_BLOB_COUNT) * 32000) ="
+	@echo "TO_DA_FOOTPRINT_GAS_SCALAR=$$(( $(TO_GAS_LIMIT) / ($(TO_ELASTICITY) * $(TARGET_BLOB_COUNT) * 32000) ))"
+
 .PHONY: gen-validation
 gen-validation: checkout-signer-tool run-script
 

--- a/mainnet/2025-12-08-increase-gas-and-elasticity-limit/README.md
+++ b/mainnet/2025-12-08-increase-gas-and-elasticity-limit/README.md
@@ -8,7 +8,7 @@ We are updating the gas limit, elasticity, and DA footprint gas scalar to improv
 
 This runbook invokes the following script which allows our signers to sign the same call with two different sets of parameters for our Incident Multisig, defined in the [base-org/contracts](https://github.com/base/contracts) repository:
 
-`IncreaseEip1559ElasticityAndIncreaseGasLimitScript` -- This script will update the gas limit to our new limit of 187.5 Mgas/s, 6 elasticity, and 325 DA footprint gas scalar if invoked as part of the "upgrade" process, or revert to the old limit of 150 Mgas/s, 5 elasticity, and 312 DA footprint gas scalar if invoked as part of the "rollback" process.
+`IncreaseEip1559ElasticityAndIncreaseGasLimitScript` -- This script will update the gas limit to our new limit of 187.5 Mgas/s, 6 elasticity, and 195 DA footprint gas scalar if invoked as part of the "upgrade" process, or revert to the old limit of 150 Mgas/s, 5 elasticity, and 312 DA footprint gas scalar if invoked as part of the "rollback" process.
 
 ### DA Footprint Gas Scalar Formula
 

--- a/mainnet/2025-12-08-increase-gas-and-elasticity-limit/validations/base-signer-rollback.json
+++ b/mainnet/2025-12-08-increase-gas-and-elasticity-limit/validations/base-signer-rollback.json
@@ -1,5 +1,5 @@
 {
-  "cmd": "OLD_GAS_LIMIT=375000000 NEW_GAS_LIMIT=300000000 OLD_ELASTICITY=6 NEW_ELASTICITY=5 OLD_DA_FOOTPRINT_GAS_SCALAR=325 NEW_DA_FOOTPRINT_GAS_SCALAR=312 SAFE_NONCE=99 forge script --rpc-url https://eth-mainnet.public.blastapi.io IncreaseEip1559ElasticityAndIncreaseGasLimitScript --sig sign(address[]) [] --sender 0x1841CB3C2ce6870D0417844C817849da64E6e937",
+  "cmd": "OLD_GAS_LIMIT=375000000 NEW_GAS_LIMIT=300000000 OLD_ELASTICITY=6 NEW_ELASTICITY=5 OLD_DA_FOOTPRINT_GAS_SCALAR=195 NEW_DA_FOOTPRINT_GAS_SCALAR=312 SAFE_NONCE=99 forge script --rpc-url https://eth-mainnet.public.blastapi.io IncreaseEip1559ElasticityAndIncreaseGasLimitScript --sig sign(address[]) [] --sender 0x1841CB3C2ce6870D0417844C817849da64E6e937",
   "ledgerId": 0,
   "rpcUrl": "https://eth-mainnet.public.blastapi.io",
   "expectedDomainAndMessageHashes": {
@@ -44,8 +44,8 @@
         },
         {
           "key": "0x000000000000000000000000000000000000000000000000000000000000006a",
-          "value": "0x0000000000000000000001450000000000000000000000000000000600000032",
-          "description": "Overrides elasticity to 6 and DA Footprint Gas Scalar to 312 for the chain",
+          "value": "0x0000000000000000000000c30000000000000000000000000000000600000032",
+          "description": "Overrides elasticity to 6 and DA Footprint Gas Scalar to 195 for the chain",
           "allowDifference": false
         }
       ]
@@ -78,7 +78,7 @@
         },
         {
           "key": "0x000000000000000000000000000000000000000000000000000000000000006a",
-          "before": "0x0000000000000000000001450000000000000000000000000000000600000032",
+          "before": "0x0000000000000000000000c30000000000000000000000000000000600000032",
           "after": "0x0000000000000000000001380000000000000000000000000000000500000032",
           "description": "Sets the DA Footprint Gas Scalar to 312 (0x0138) and elasticity to 5",
           "allowDifference": false

--- a/mainnet/2025-12-08-increase-gas-and-elasticity-limit/validations/base-signer.json
+++ b/mainnet/2025-12-08-increase-gas-and-elasticity-limit/validations/base-signer.json
@@ -1,11 +1,11 @@
 {
-  "cmd": "NEW_GAS_LIMIT=375000000 OLD_GAS_LIMIT=300000000 NEW_ELASTICITY=6 OLD_ELASTICITY=5 NEW_DA_FOOTPRINT_GAS_SCALAR=325 OLD_DA_FOOTPRINT_GAS_SCALAR=312 forge script --rpc-url https://eth-mainnet.public.blastapi.io IncreaseEip1559ElasticityAndIncreaseGasLimitScript --sig sign(address[]) [] --sender 0x1841CB3C2ce6870D0417844C817849da64E6e937",
+  "cmd": "NEW_GAS_LIMIT=375000000 OLD_GAS_LIMIT=300000000 NEW_ELASTICITY=6 OLD_ELASTICITY=5 NEW_DA_FOOTPRINT_GAS_SCALAR=195 OLD_DA_FOOTPRINT_GAS_SCALAR=312 forge script --rpc-url https://eth-mainnet.public.blastapi.io IncreaseEip1559ElasticityAndIncreaseGasLimitScript --sig sign(address[]) [] --sender 0x1841CB3C2ce6870D0417844C817849da64E6e937",
   "ledgerId": 0,
   "rpcUrl": "https://eth-mainnet.public.blastapi.io",
   "expectedDomainAndMessageHashes": {
     "address": "0x14536667Cd30e52C0b458BaACcB9faDA7046E056",
     "domainHash": "0xf3474c66ee08325b410c3f442c878d01ec97dd55a415a307e9d7d2ea24336289",
-    "messageHash": "0x078904e595c692904bcd7d168bc2e3af2ab6b46fd1b04de80a0cbe229b556546"
+    "messageHash": "0xcae13e15573f37f4c0255603291dee84df7077399abe102d5e480748e72b278d"
   },
   "stateOverrides": [
     {
@@ -19,7 +19,7 @@
           "allowDifference": false
         },
         {
-          "key": "0x8eeabbb23f3bfdfab569e1cc3dd5173b8c9cd64a5281121a09af7528f936f603",
+          "key": "0xa3944572eb14b588707d0a0ae055bb83cbf4a8207804b207918c8e8a34e22e04",
           "value": "0x0000000000000000000000000000000000000000000000000000000000000001",
           "description": "Simulates an approval from msg.sender in order for the task simulation to succeed.",
           "allowDifference": false
@@ -55,8 +55,8 @@
         {
           "key": "0x000000000000000000000000000000000000000000000000000000000000006a",
           "before": "0x0000000000000000000001380000000000000000000000000000000500000032",
-          "after": "0x0000000000000000000001450000000000000000000000000000000600000032",
-          "description": "Sets the DA Footprint Gas Scalar to 325 (0x0145) and elasticity to 6",
+          "after": "0x0000000000000000000000c30000000000000000000000000000000600000032",
+          "description": "Sets the DA Footprint Gas Scalar to 195 (0x00c3) and elasticity to 6",
           "allowDifference": false
         }
       ]


### PR DESCRIPTION
The original DA scalar was calculated with the old blob target of 6. Recalculated using blob target = 10:
TO_DA_FOOTPRINT_GAS_SCALAR = 375M / (6 * 10 * 32000) = 195