### PR TITLE
docs: add solana to supported networks list

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repo contains execution code and artifacts related to Base contract deployments, upgrades, and calls. For actual contract implementations, see [base/contracts](https://github.com/base/contracts).
 
-This repo is structured with each network having a high-level directory which contains subdirectories of any "tasks" (contract deployments/calls) that have happened for that network. Supported networks are `mainnet`, `sepolia`, and `sepolia-alpha`.
+This repo is structured with each network having a high-level directory which contains subdirectories of any "tasks" (contract deployments/calls) that have happened for that network. Supported networks are `mainnet`, `sepolia`, `sepolia-alpha`, and `solana`.
 
 <!-- Badge row 1 - status -->
 


### PR DESCRIPTION
README listed only EVM networks, omitting solana dir