### PR TITLE
feat: Mainnet gas limit & EIP-1559 params update

### DIFF
--- a/mainnet/2026-03-25-increase-gas-and-elasticity-limit/.env
+++ b/mainnet/2026-03-25-increase-gas-and-elasticity-limit/.env
@@ -1,0 +1,35 @@
+# Required: Git commit hash for https://github.com/base/contracts
+BASE_CONTRACTS_COMMIT=be7c7a642e430fa64b04b63203839f8c81f48466
+
+# Network-specific addresses are automatically loaded from {network}/.env via include ../.env
+
+# Required: Current gas limit on chain (for validation)
+FROM_GAS_LIMIT=375000000
+
+# Required: New gas limit to set
+TO_GAS_LIMIT=400000000
+
+# Required: Current EIP-1559 elasticity on chain (for validation)
+FROM_ELASTICITY=6
+
+# Required: New EIP-1559 elasticity to set
+TO_ELASTICITY=5
+
+# Required: Current EIP-1559 denominator on chain (for validation)
+FROM_DENOMINATOR=125
+
+# Required: New EIP-1559 denominator to set
+TO_DENOMINATOR=100
+
+# Required: Current DA footprint gas scalar on chain (for validation)
+FROM_DA_FOOTPRINT_GAS_SCALAR=139
+
+# Required: New DA footprint gas scalar to set
+# Anchored to L1 blob limit (21 blobs): gas_limit / (21 * 128,000)
+TO_DA_FOOTPRINT_GAS_SCALAR=148
+
+# Required: Address of a signer on OWNER_SAFE (used for simulation)
+SENDER=0x1841CB3C2ce6870D0417844C817849da64E6e937
+
+# Enable state diff recording for validation
+RECORD_STATE_DIFF=true

--- a/mainnet/2026-03-25-increase-gas-and-elasticity-limit/FACILITATOR.md
+++ b/mainnet/2026-03-25-increase-gas-and-elasticity-limit/FACILITATOR.md
@@ -1,0 +1,49 @@
+# Facilitator Guide
+
+Guide for facilitators managing this task.
+
+## Task Origin Signing
+
+After setting up the task, generate cryptographic attestations (sigstore bundles) to prove who created and facilitated the task. These signatures are stored in `<network>/signatures/<task-name>/`.
+
+### Task creator (run after task setup):
+```bash
+make sign-as-task-creator
+```
+
+### Base facilitator:
+```bash
+make sign-as-base-facilitator
+```
+
+### Security Council facilitator:
+```bash
+make sign-as-sc-facilitator
+```
+
+## Execution
+
+### 1. Update repo:
+
+```bash
+cd contract-deployments
+git pull
+cd <network>/<task-name>
+make deps
+```
+
+### 2. Execute upgrade
+
+```bash
+SIGNATURES=AAABBBCCC make execute
+```
+
+### 3. (**ONLY** if needed) Execute upgrade rollback
+
+> [!IMPORTANT]
+>
+> THIS SHOULD ONLY BE PERFORMED IN THE EVENT THAT WE NEED TO ROLLBACK
+
+```bash
+SIGNATURES=AAABBBCCC make execute-rollback
+```

--- a/mainnet/2026-03-25-increase-gas-and-elasticity-limit/Makefile
+++ b/mainnet/2026-03-25-increase-gas-and-elasticity-limit/Makefile
@@ -1,0 +1,85 @@
+include ../../Makefile
+include ../../Multisig.mk
+include ../.env
+include .env
+
+# Map config variables to script variables
+OWNER_SAFE ?= $(INCIDENT_MULTISIG)
+export OWNER_SAFE
+
+ifndef ROLLBACK_NONCE_OFFSET
+override ROLLBACK_NONCE_OFFSET = 1
+endif
+
+RPC_URL = $(L1_RPC_URL)
+SCRIPT_NAME = IncreaseEip1559ElasticityAndIncreaseGasLimitScript
+
+# Validate required configuration before execution
+.PHONY: validate-config
+validate-config:
+	@test -n "$(BASE_CONTRACTS_COMMIT)" -a "$(BASE_CONTRACTS_COMMIT)" != "TODO" || (echo "BASE_CONTRACTS_COMMIT required" && exit 1)
+	@test -n "$(OWNER_SAFE)" || (echo "OWNER_SAFE required" && exit 1)
+	@test -n "$(SYSTEM_CONFIG)" || (echo "SYSTEM_CONFIG required" && exit 1)
+	@test -n "$(SENDER)" || (echo "SENDER required" && exit 1)
+	@test -n "$(FROM_GAS_LIMIT)" -a "$(FROM_GAS_LIMIT)" != "TODO" || (echo "FROM_GAS_LIMIT required" && exit 1)
+	@test -n "$(TO_GAS_LIMIT)" -a "$(TO_GAS_LIMIT)" != "TODO" || (echo "TO_GAS_LIMIT required" && exit 1)
+	@test -n "$(FROM_ELASTICITY)" -a "$(FROM_ELASTICITY)" != "TODO" || (echo "FROM_ELASTICITY required" && exit 1)
+	@test -n "$(TO_ELASTICITY)" -a "$(TO_ELASTICITY)" != "TODO" || (echo "TO_ELASTICITY required" && exit 1)
+	@test -n "$(FROM_DENOMINATOR)" -a "$(FROM_DENOMINATOR)" != "TODO" || (echo "FROM_DENOMINATOR required" && exit 1)
+	@test -n "$(TO_DENOMINATOR)" -a "$(TO_DENOMINATOR)" != "TODO" || (echo "TO_DENOMINATOR required" && exit 1)
+	@test -n "$(FROM_DA_FOOTPRINT_GAS_SCALAR)" -a "$(FROM_DA_FOOTPRINT_GAS_SCALAR)" != "TODO" || (echo "FROM_DA_FOOTPRINT_GAS_SCALAR required" && exit 1)
+	@test -n "$(TO_DA_FOOTPRINT_GAS_SCALAR)" -a "$(TO_DA_FOOTPRINT_GAS_SCALAR)" != "TODO" || (echo "TO_DA_FOOTPRINT_GAS_SCALAR required" && exit 1)
+	@echo "Configuration validated successfully"
+
+# Calculate the DA footprint gas scalar based on the formula:
+# da_footprint_gas_scalar = gas_limit / (elasticity * target_blob_count * 32,000)
+# Uses TO_GAS_LIMIT and TO_ELASTICITY from .env
+.PHONY: da-scalar
+da-scalar:
+ifndef TARGET_BLOB_COUNT
+	$(error TARGET_BLOB_COUNT is not set. Usage: make da-scalar TARGET_BLOB_COUNT=<value>)
+endif
+ifeq ($(TO_GAS_LIMIT),TODO)
+	$(error TO_GAS_LIMIT is not set. Please set it in .env before running this command.)
+endif
+ifeq ($(TO_ELASTICITY),TODO)
+	$(error TO_ELASTICITY is not set. Please set it in .env before running this command.)
+endif
+	@echo "$(TO_GAS_LIMIT) / ($(TO_ELASTICITY) * $(TARGET_BLOB_COUNT) * 32000) ="
+	@echo "TO_DA_FOOTPRINT_GAS_SCALAR=$$(( $(TO_GAS_LIMIT) / ($(TO_ELASTICITY) * $(TARGET_BLOB_COUNT) * 32000) ))"
+
+.PHONY: gen-validation
+gen-validation: validate-config deps-signer-tool
+	$(call GEN_VALIDATION,$(SCRIPT_NAME),,$(SENDER),base-signer.json,OWNER_SAFE=$(OWNER_SAFE) SYSTEM_CONFIG=$(SYSTEM_CONFIG) NEW_GAS_LIMIT=$(TO_GAS_LIMIT) OLD_GAS_LIMIT=$(FROM_GAS_LIMIT) NEW_ELASTICITY=$(TO_ELASTICITY) OLD_ELASTICITY=$(FROM_ELASTICITY) NEW_DENOMINATOR=$(TO_DENOMINATOR) OLD_DENOMINATOR=$(FROM_DENOMINATOR) NEW_DA_FOOTPRINT_GAS_SCALAR=$(TO_DA_FOOTPRINT_GAS_SCALAR) OLD_DA_FOOTPRINT_GAS_SCALAR=$(FROM_DA_FOOTPRINT_GAS_SCALAR))
+
+.PHONY: execute
+execute: validate-config
+	NEW_GAS_LIMIT=$(TO_GAS_LIMIT) \
+	OLD_GAS_LIMIT=$(FROM_GAS_LIMIT) \
+	NEW_ELASTICITY=$(TO_ELASTICITY) \
+	OLD_ELASTICITY=$(FROM_ELASTICITY) \
+	NEW_DENOMINATOR=$(TO_DENOMINATOR) \
+	OLD_DENOMINATOR=$(FROM_DENOMINATOR) \
+	NEW_DA_FOOTPRINT_GAS_SCALAR=$(TO_DA_FOOTPRINT_GAS_SCALAR) \
+	OLD_DA_FOOTPRINT_GAS_SCALAR=$(FROM_DA_FOOTPRINT_GAS_SCALAR) \
+	$(call MULTISIG_EXECUTE,$(SIGNATURES))
+
+# Generate rollback validation file with swapped old/new values and nonce offset.
+# SAFE_NONCE is set to current_nonce + ROLLBACK_NONCE_OFFSET so the rollback
+# transaction targets the correct future nonce.
+.PHONY: gen-validation-rollback
+gen-validation-rollback: validate-config deps-signer-tool
+	$(call GEN_VALIDATION,$(SCRIPT_NAME),,$(SENDER),base-signer-rollback.json,OWNER_SAFE=$(OWNER_SAFE) SYSTEM_CONFIG=$(SYSTEM_CONFIG) OLD_GAS_LIMIT=$(TO_GAS_LIMIT) NEW_GAS_LIMIT=$(FROM_GAS_LIMIT) OLD_ELASTICITY=$(TO_ELASTICITY) NEW_ELASTICITY=$(FROM_ELASTICITY) OLD_DENOMINATOR=$(TO_DENOMINATOR) NEW_DENOMINATOR=$(FROM_DENOMINATOR) OLD_DA_FOOTPRINT_GAS_SCALAR=$(TO_DA_FOOTPRINT_GAS_SCALAR) NEW_DA_FOOTPRINT_GAS_SCALAR=$(FROM_DA_FOOTPRINT_GAS_SCALAR) SAFE_NONCE=$(shell expr $(call GET_NONCE,$(OWNER_SAFE)) + $(ROLLBACK_NONCE_OFFSET)))
+
+.PHONY: execute-rollback
+execute-rollback: validate-config
+	OLD_GAS_LIMIT=$(TO_GAS_LIMIT) \
+	NEW_GAS_LIMIT=$(FROM_GAS_LIMIT) \
+	OLD_ELASTICITY=$(TO_ELASTICITY) \
+	NEW_ELASTICITY=$(FROM_ELASTICITY) \
+	OLD_DENOMINATOR=$(TO_DENOMINATOR) \
+	NEW_DENOMINATOR=$(FROM_DENOMINATOR) \
+	OLD_DA_FOOTPRINT_GAS_SCALAR=$(TO_DA_FOOTPRINT_GAS_SCALAR) \
+	NEW_DA_FOOTPRINT_GAS_SCALAR=$(FROM_DA_FOOTPRINT_GAS_SCALAR) \
+	SAFE_NONCE=$(shell expr $(call GET_NONCE,$(OWNER_SAFE)) + $(ROLLBACK_NONCE_OFFSET)) \
+	$(call MULTISIG_EXECUTE,$(SIGNATURES))

--- a/mainnet/2026-03-25-increase-gas-and-elasticity-limit/README.md
+++ b/mainnet/2026-03-25-increase-gas-and-elasticity-limit/README.md
@@ -1,0 +1,96 @@
+# Update Gas Limit, EIP-1559 Params & DA Footprint Gas Scalar in L1 `SystemConfig`
+
+Status: READY TO SIGN
+
+## Description
+
+We are updating the gas limit, EIP-1559 elasticity, EIP-1559 denominator, and DA footprint gas scalar to improve TPS and reduce gas fees.
+
+This runbook invokes the following script which allows our signers to sign the same call with two different sets of parameters for our Incident Multisig, defined in the [base-org/contracts](https://github.com/base/contracts) repository:
+
+`IncreaseEip1559ElasticityAndIncreaseGasLimitScript` -- This script will update the gas limit to 400,000,000, elasticity to 5, denominator to 100, and DA footprint gas scalar to 148 if invoked as part of the "upgrade" process, or revert to the old limit of 375,000,000 gas, elasticity of 6, denominator of 125, and DA footprint gas scalar of 139 if invoked as part of the "rollback" process.
+
+### DA Footprint Gas Scalar Formula
+
+We typically set the DA footprint gas scalar to cause base fees to rise if and only if the DA usage exceeds the L1 target blob throughput. (Below that level of DA usage, the normal base fee rules apply.) We use the following formula:
+
+```
+da_footprint_gas_scalar = gas_limit / (elasticity * l2_block_time * l1_target_throughput * estimation_ratio)
+```
+
+Where:
+- `gas_limit` = L2 gas limit per block
+- `elasticity` = EIP-1559 elasticity multiplier
+- `l2_block_time` = 2 seconds
+- `l1_target_throughput = (target_blob_count * 128,000 bytes/blob) / 12 sec/block`
+- `target_blob_count` = target number of blobs per L1 block
+- `estimation_ratio` = 1.5 to account for differences between compression estimates and actual usage
+
+This simplifies to:
+
+```
+da_footprint_gas_scalar = gas_limit / (elasticity * target_blob_count * 32,000)
+```
+
+Example with gas_limit = 120,000,000, elasticity = 2, and target_blob_count = 6:
+```
+da_footprint_gas_scalar = 120,000,000 / (2 * 6 * 32,000) = 312.5 ≈ 312
+```
+
+The values we are sending are statically defined in the `.env` file.
+
+> [!IMPORTANT] We have two transactions to sign. Please follow
+> the flow for both "Approving the Update transaction" and
+> "Approving the Rollback transaction". Hopefully we only need
+> the former, but will have the latter available if needed.
+
+## Install dependencies
+
+### 1. Update foundry
+
+```bash
+foundryup
+```
+
+### 2. Install Node.js if needed
+
+First, check if you have node installed
+
+```bash
+node --version
+```
+
+If you see a version output from the above command, you can move on. Otherwise, install node
+
+```bash
+brew install node
+```
+
+## Approving the Update transaction
+
+### 1. Update repo:
+
+```bash
+cd contract-deployments
+git pull
+```
+
+### 2. Run the signing tool (NOTE: do not enter the task directory. Run this command from the project's root).
+
+```bash
+make sign-task
+```
+
+### 3. Open the UI at [http://localhost:3000](http://localhost:3000)
+
+Be sure to select the correct task from the list of available tasks to sign (**not** the "Base Signer Rollback" task). Copy the resulting signature and save it.
+
+### 4. Rollback signing
+
+Now, click on the "Base Signer" selection and switch over to the rollback task (called "Base Signer Rollback"). Copy the resulting signature and save it.
+
+### 5. Send signature to facilitator
+
+Send the two signatures to the facilitator and make sure to clearly note which one is the primary one and which one is the rollback.
+
+You may now kill the Signer Tool process in your terminal window by running `Ctrl + C`.

--- a/mainnet/2026-03-25-increase-gas-and-elasticity-limit/foundry.toml
+++ b/mainnet/2026-03-25-increase-gas-and-elasticity-limit/foundry.toml
@@ -1,0 +1,24 @@
+[profile.default]
+src = 'src'
+out = 'out'
+libs = ['lib']
+broadcast = 'records'
+fs_permissions = [ {access = "read-write", path = "./"} ]
+optimizer = true
+optimizer_runs = 999999
+solc_version = "0.8.15"
+via-ir = false
+evm_version = "shanghai"
+remappings = [
+    '@eth-optimism-bedrock/=lib/optimism/packages/contracts-bedrock/',
+    '@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts',
+    '@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts',
+    '@rari-capital/solmate/=lib/solmate/',
+    '@base-contracts/=lib/contracts',
+    '@solady/=lib/solady/src/'
+]
+
+[lint]
+lint_on_build = false
+
+# See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/mainnet/2026-03-25-increase-gas-and-elasticity-limit/script/IncreaseEip1559ElasticityAndIncreaseGasLimit.s.sol
+++ b/mainnet/2026-03-25-increase-gas-and-elasticity-limit/script/IncreaseEip1559ElasticityAndIncreaseGasLimit.s.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {Vm} from "forge-std/Vm.sol";
+
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
+import {MultisigScript} from "@base-contracts/script/universal/MultisigScript.sol";
+import {Enum} from "@base-contracts/script/universal/IGnosisSafe.sol";
+
+interface ISystemConfig {
+    function eip1559Elasticity() external view returns (uint32);
+    function eip1559Denominator() external view returns (uint32);
+    function setEIP1559Params(uint32 _denominator, uint32 _elasticity) external;
+    function gasLimit() external view returns (uint64);
+    function setGasLimit(uint64 _gasLimit) external;
+    function daFootprintGasScalar() external view returns (uint16);
+    function setDAFootprintGasScalar(uint16 _daFootprintGasScalar) external;
+}
+
+contract IncreaseEip1559ElasticityAndIncreaseGasLimitScript is MultisigScript {
+    address internal immutable OWNER_SAFE;
+    address internal immutable SYSTEM_CONFIG;
+
+    uint32 internal immutable ELASTICITY;
+    uint32 internal immutable NEW_ELASTICITY;
+    uint64 internal immutable GAS_LIMIT;
+    uint64 internal immutable NEW_GAS_LIMIT;
+    uint32 internal immutable DENOMINATOR;
+    uint32 internal immutable NEW_DENOMINATOR;
+    uint16 internal immutable DA_FOOTPRINT_GAS_SCALAR;
+    uint16 internal immutable NEW_DA_FOOTPRINT_GAS_SCALAR;
+
+    constructor() {
+        OWNER_SAFE = vm.envAddress("OWNER_SAFE");
+        SYSTEM_CONFIG = vm.envAddress("SYSTEM_CONFIG");
+
+        GAS_LIMIT = uint64(vm.envUint("OLD_GAS_LIMIT"));
+        NEW_GAS_LIMIT = uint64(vm.envUint("NEW_GAS_LIMIT"));
+
+        ELASTICITY = uint32(vm.envUint("OLD_ELASTICITY"));
+        NEW_ELASTICITY = uint32(vm.envUint("NEW_ELASTICITY"));
+
+        DENOMINATOR = uint32(vm.envUint("OLD_DENOMINATOR"));
+        NEW_DENOMINATOR = uint32(vm.envUint("NEW_DENOMINATOR"));
+
+        DA_FOOTPRINT_GAS_SCALAR = uint16(vm.envUint("OLD_DA_FOOTPRINT_GAS_SCALAR"));
+        NEW_DA_FOOTPRINT_GAS_SCALAR = uint16(vm.envUint("NEW_DA_FOOTPRINT_GAS_SCALAR"));
+    }
+
+    function _postCheck(Vm.AccountAccess[] memory, Simulation.Payload memory) internal view override {
+        vm.assertEq(ISystemConfig(SYSTEM_CONFIG).eip1559Denominator(), NEW_DENOMINATOR, "Denominator mismatch");
+        vm.assertEq(ISystemConfig(SYSTEM_CONFIG).eip1559Elasticity(), NEW_ELASTICITY, "Elasticity mismatch");
+        vm.assertEq(ISystemConfig(SYSTEM_CONFIG).gasLimit(), NEW_GAS_LIMIT, "Gas Limit mismatch");
+        vm.assertEq(
+            ISystemConfig(SYSTEM_CONFIG).daFootprintGasScalar(),
+            NEW_DA_FOOTPRINT_GAS_SCALAR,
+            "DA Footprint Gas Scalar mismatch"
+        );
+    }
+
+    function _simulationOverrides() internal view override returns (Simulation.StateOverride[] memory _stateOverrides) {
+        if (
+            GAS_LIMIT != ISystemConfig(SYSTEM_CONFIG).gasLimit()
+                || ELASTICITY != ISystemConfig(SYSTEM_CONFIG).eip1559Elasticity()
+                || DENOMINATOR != ISystemConfig(SYSTEM_CONFIG).eip1559Denominator()
+                || DA_FOOTPRINT_GAS_SCALAR != ISystemConfig(SYSTEM_CONFIG).daFootprintGasScalar()
+        ) {
+            // Override SystemConfig state to the expected "from" values so simulations succeeds even
+            // when the chain already reflects the post-change values (during rollback simulation).
+
+            // Prepare two storage overrides for SystemConfig
+            Simulation.StateOverride[] memory stateOverrides = new Simulation.StateOverride[](1);
+            Simulation.StorageOverride[] memory storageOverrides = new Simulation.StorageOverride[](2);
+
+            // Load current packed gas config (slot 0x68) and replace only the lower 64 bits with GAS_LIMIT
+            bytes32 gasConfigSlotKey = bytes32(uint256(0x68));
+            uint256 gasConfigWord = uint256(vm.load(SYSTEM_CONFIG, gasConfigSlotKey));
+            uint256 updatedGasConfigWord = (gasConfigWord & ~uint256(0xffffffffffffffff)) | uint256(GAS_LIMIT);
+            storageOverrides[0] =
+                Simulation.StorageOverride({key: gasConfigSlotKey, value: bytes32(updatedGasConfigWord)});
+
+            // Update EIP-1559 params and DA Footprint Gas Scalar (slot 0x6a)
+            // Storage layout (low to high bits):
+            //   - eip1559Denominator (uint32): bits 0-31
+            //   - eip1559Elasticity (uint32): bits 32-63
+            //   - operatorFeeScalar (uint32): bits 64-95
+            //   - operatorFeeConstant (uint64): bits 96-159
+            //   - daFootprintGasScalar (uint16): bits 160-175
+            // Load existing slot to preserve operatorFeeScalar and operatorFeeConstant, then update
+            // the fields we care about.
+            bytes32 eip1559SlotKey = bytes32(uint256(0x6a));
+            uint256 existingEip1559Word = uint256(vm.load(SYSTEM_CONFIG, eip1559SlotKey));
+            // Mask to preserve bits 64-159 (operatorFeeScalar and operatorFeeConstant)
+            uint256 operatorFeeMask = uint256(0xFFFFFFFFFFFFFFFFFFFFFFFF) << 64;
+            uint256 preservedOperatorFees = existingEip1559Word & operatorFeeMask;
+            uint256 composedEip1559Word = (uint256(DA_FOOTPRINT_GAS_SCALAR) << 160) | preservedOperatorFees
+                | (uint256(ELASTICITY) << 32) | uint256(DENOMINATOR);
+            storageOverrides[1] = Simulation.StorageOverride({key: eip1559SlotKey, value: bytes32(composedEip1559Word)});
+
+            stateOverrides[0] = Simulation.StateOverride({contractAddress: SYSTEM_CONFIG, overrides: storageOverrides});
+            return stateOverrides;
+        }
+    }
+
+    function _buildCalls() internal view override returns (Call[] memory) {
+        Call[] memory calls = new Call[](3);
+
+        calls[0] = Call({
+            operation: Enum.Operation.Call,
+            target: SYSTEM_CONFIG,
+            data: abi.encodeCall(ISystemConfig.setEIP1559Params, (NEW_DENOMINATOR, NEW_ELASTICITY)),
+            value: 0
+        });
+
+        calls[1] = Call({
+            operation: Enum.Operation.Call,
+            target: SYSTEM_CONFIG,
+            data: abi.encodeCall(ISystemConfig.setGasLimit, (NEW_GAS_LIMIT)),
+            value: 0
+        });
+
+        calls[2] = Call({
+            operation: Enum.Operation.Call,
+            target: SYSTEM_CONFIG,
+            data: abi.encodeCall(ISystemConfig.setDAFootprintGasScalar, (NEW_DA_FOOTPRINT_GAS_SCALAR)),
+            value: 0
+        });
+
+        return calls;
+    }
+
+    function _ownerSafe() internal view override returns (address) {
+        return OWNER_SAFE;
+    }
+}

--- a/mainnet/2026-03-25-increase-gas-and-elasticity-limit/validations/base-signer-rollback.json
+++ b/mainnet/2026-03-25-increase-gas-and-elasticity-limit/validations/base-signer-rollback.json
@@ -1,0 +1,96 @@
+{
+  "cmd": "OWNER_SAFE=0x14536667Cd30e52C0b458BaACcB9faDA7046E056 SYSTEM_CONFIG=0x73a79Fab69143498Ed3712e519A88a918e1f4072 OLD_GAS_LIMIT=400000000 NEW_GAS_LIMIT=375000000 OLD_ELASTICITY=5 NEW_ELASTICITY=6 OLD_DENOMINATOR=100 NEW_DENOMINATOR=125 OLD_DA_FOOTPRINT_GAS_SCALAR=148 NEW_DA_FOOTPRINT_GAS_SCALAR=139 SAFE_NONCE=105 forge script --rpc-url https://eth-mainnet.public.blastapi.io IncreaseEip1559ElasticityAndIncreaseGasLimitScript --sig sign(address[]) [] --sender 0x1841CB3C2ce6870D0417844C817849da64E6e937",
+  "ledgerId": 0,
+  "rpcUrl": "https://eth-mainnet.public.blastapi.io",
+  "expectedDomainAndMessageHashes": {
+    "address": "0x14536667Cd30e52C0b458BaACcB9faDA7046E056",
+    "domainHash": "0xf3474c66ee08325b410c3f442c878d01ec97dd55a415a307e9d7d2ea24336289",
+    "messageHash": "0x26a19e1e19c9dd593b254574af1c18ab62b00f4e36d4cd554891a02617f3f7cc"
+  },
+  "stateOverrides": [
+    {
+      "name": "Incident Safe - Mainnet",
+      "address": "0x14536667Cd30e52C0b458BaACcB9faDA7046E056",
+      "overrides": [
+        {
+          "key": "0x0000000000000000000000000000000000000000000000000000000000000004",
+          "value": "0x0000000000000000000000000000000000000000000000000000000000000001",
+          "description": "Override the threshold to 1 so the transaction simulation can occur.",
+          "allowDifference": false
+        },
+        {
+          "key": "0x0000000000000000000000000000000000000000000000000000000000000005",
+          "value": "0x0000000000000000000000000000000000000000000000000000000000000069",
+          "description": "Override the nonce to be our expected value after initial execution.",
+          "allowDifference": false
+        },
+        {
+          "key": "0xc6edbbe6d06beac67af3a930fafb3f0c0505c89cd6ad26f26b9501da24434821",
+          "value": "0x0000000000000000000000000000000000000000000000000000000000000001",
+          "description": "Simulates an approval from msg.sender in order for the task simulation to succeed.",
+          "allowDifference": false
+        }
+      ]
+    },
+    {
+      "name": "System Config - Mainnet",
+      "address": "0x73a79Fab69143498Ed3712e519A88a918e1f4072",
+      "overrides": [
+        {
+          "key": "0x0000000000000000000000000000000000000000000000000000000000000068",
+          "value": "0x0000000000000000000000000000000000101c12000008dd0000000017d78400",
+          "description": "Overrides gas limit to post-upgrade value (400,000,000) so rollback simulation succeeds",
+          "allowDifference": false
+        },
+        {
+          "key": "0x000000000000000000000000000000000000000000000000000000000000006a",
+          "value": "0x0000000000000000000000940000000000000000000000000000000500000064",
+          "description": "Overrides EIP-1559 params and DA footprint gas scalar to post-upgrade values so rollback simulation succeeds",
+          "allowDifference": false
+        }
+      ]
+    }
+  ],
+  "stateChanges": [
+    {
+      "name": "Incident Safe - Mainnet",
+      "address": "0x14536667Cd30e52C0b458BaACcB9faDA7046E056",
+      "changes": [
+        {
+          "key": "0x0000000000000000000000000000000000000000000000000000000000000005",
+          "before": "0x0000000000000000000000000000000000000000000000000000000000000069",
+          "after": "0x000000000000000000000000000000000000000000000000000000000000006a",
+          "description": "Increments the nonce",
+          "allowDifference": false
+        }
+      ]
+    },
+    {
+      "name": "System Config - Mainnet",
+      "address": "0x73a79Fab69143498Ed3712e519A88a918e1f4072",
+      "changes": [
+        {
+          "key": "0x0000000000000000000000000000000000000000000000000000000000000068",
+          "before": "0x0000000000000000000000000000000000101c12000008dd0000000017d78400",
+          "after": "0x0000000000000000000000000000000000101c12000008dd00000000165a0bc0",
+          "description": "Reverts the gas limit from 400,000,000 back to 375,000,000",
+          "allowDifference": false
+        },
+        {
+          "key": "0x000000000000000000000000000000000000000000000000000000000000006a",
+          "before": "0x0000000000000000000000940000000000000000000000000000000500000064",
+          "after": "0x00000000000000000000008b000000000000000000000000000000060000007d",
+          "description": "Updates EIP-1559 params (denominator, elasticity) and DA Footprint Gas Scalar for the chain",
+          "allowDifference": false
+        }
+      ]
+    }
+  ],
+  "balanceChanges": [],
+  "skipTaskOriginValidation": true,
+  "taskOriginConfig": {
+    "taskCreator": {
+      "commonName": "leopold.joy@coinbase.com"
+    }
+  }
+}

--- a/mainnet/2026-03-25-increase-gas-and-elasticity-limit/validations/base-signer.json
+++ b/mainnet/2026-03-25-increase-gas-and-elasticity-limit/validations/base-signer.json
@@ -1,0 +1,72 @@
+{
+  "cmd": "OWNER_SAFE=0x14536667Cd30e52C0b458BaACcB9faDA7046E056 SYSTEM_CONFIG=0x73a79Fab69143498Ed3712e519A88a918e1f4072 NEW_GAS_LIMIT=400000000 OLD_GAS_LIMIT=375000000 NEW_ELASTICITY=5 OLD_ELASTICITY=6 NEW_DENOMINATOR=100 OLD_DENOMINATOR=125 NEW_DA_FOOTPRINT_GAS_SCALAR=148 OLD_DA_FOOTPRINT_GAS_SCALAR=139 forge script --rpc-url https://eth-mainnet.public.blastapi.io IncreaseEip1559ElasticityAndIncreaseGasLimitScript --sig sign(address[]) [] --sender 0x1841CB3C2ce6870D0417844C817849da64E6e937",
+  "ledgerId": 0,
+  "rpcUrl": "https://eth-mainnet.public.blastapi.io",
+  "expectedDomainAndMessageHashes": {
+    "address": "0x14536667Cd30e52C0b458BaACcB9faDA7046E056",
+    "domainHash": "0xf3474c66ee08325b410c3f442c878d01ec97dd55a415a307e9d7d2ea24336289",
+    "messageHash": "0xf919188ede592321fa24fc431d5cbf603c705947a97383c8b678762e1c058346"
+  },
+  "stateOverrides": [
+    {
+      "name": "Incident Safe - Mainnet",
+      "address": "0x14536667Cd30e52C0b458BaACcB9faDA7046E056",
+      "overrides": [
+        {
+          "key": "0x0000000000000000000000000000000000000000000000000000000000000004",
+          "value": "0x0000000000000000000000000000000000000000000000000000000000000001",
+          "description": "Override the threshold to 1 so the transaction simulation can occur.",
+          "allowDifference": false
+        },
+        {
+          "key": "0x3beade20373f7a410f579a325ce98e80864139807a4531e2131af2d5a2068ba7",
+          "value": "0x0000000000000000000000000000000000000000000000000000000000000001",
+          "description": "Simulates an approval from msg.sender in order for the task simulation to succeed.",
+          "allowDifference": false
+        }
+      ]
+    }
+  ],
+  "stateChanges": [
+    {
+      "name": "Incident Safe - Mainnet",
+      "address": "0x14536667Cd30e52C0b458BaACcB9faDA7046E056",
+      "changes": [
+        {
+          "key": "0x0000000000000000000000000000000000000000000000000000000000000005",
+          "before": "0x0000000000000000000000000000000000000000000000000000000000000068",
+          "after": "0x0000000000000000000000000000000000000000000000000000000000000069",
+          "description": "Increments the nonce",
+          "allowDifference": false
+        }
+      ]
+    },
+    {
+      "name": "System Config - Mainnet",
+      "address": "0x73a79Fab69143498Ed3712e519A88a918e1f4072",
+      "changes": [
+        {
+          "key": "0x0000000000000000000000000000000000000000000000000000000000000068",
+          "before": "0x0000000000000000000000000000000000101c12000008dd00000000165a0bc0",
+          "after": "0x0000000000000000000000000000000000101c12000008dd0000000017d78400",
+          "description": "Updates the gas limit from 375,000,000 to 400,000,000",
+          "allowDifference": false
+        },
+        {
+          "key": "0x000000000000000000000000000000000000000000000000000000000000006a",
+          "before": "0x00000000000000000000008b000000000000000000000000000000060000007d",
+          "after": "0x0000000000000000000000940000000000000000000000000000000500000064",
+          "description": "Updates EIP-1559 params (denominator, elasticity) and DA Footprint Gas Scalar for the chain",
+          "allowDifference": false
+        }
+      ]
+    }
+  ],
+  "balanceChanges": [],
+  "skipTaskOriginValidation": true,
+  "taskOriginConfig": {
+    "taskCreator": {
+      "commonName": "leopold.joy@coinbase.com"
+    }
+  }
+}


### PR DESCRIPTION
Updates Mainnet SystemConfig: gas limit 375M→400M, elasticity 6→5, denominator 125→100, DA footprint gas scalar 139→148. Includes upgrade and rollback scripts based on the gas-and-elasticity-increase template with added denominator support.