### PR TITLE
Fix incorrect link for commit activity badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repo is structured with each network having a high-level directory which co
 <!-- Badge row 1 - status -->
 
 [![GitHub contributors](https://img.shields.io/github/contributors/base/contract-deployments)](https://github.com/base/contract-deployments/graphs/contributors)
-[![GitHub commit activity](https://img.shields.io/github/commit-activity/w/base/contract-deployments)](https://github.com/base/contract-deployments/graphs/contributors)
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/w/base/contract-deployments)](https://github.com/base/contract-deployments/graphs/commit-activity)
 [![GitHub Stars](https://img.shields.io/github/stars/base/contract-deployments.svg)](https://github.com/base/contract-deployments/stargazers)
 ![GitHub repo size](https://img.shields.io/github/repo-size/base/contract-deployments)
 [![GitHub](https://img.shields.io/github/license/base/contract-deployments?color=blue)](https://github.com/base/contract-deployments/blob/main/LICENSE)


### PR DESCRIPTION
Updated the "commit activity" badge link in README.md to point to the correct commit activity graph (`/graphs/commit-activity`) instead of the contributors page.