### PR TITLE
chore(CHAIN-4496): add mise to standardize tooling versions

### DIFF
--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -67,11 +67,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      # ── Foundry ──────────────────────────────────────────────────────
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
+      # ── Toolchain (mise) ─────────────────────────────────────────────
+      # Installs all tools pinned in mise.toml (foundry, node, bun, go) so
+      # CI runs match local signer environments byte-for-byte.
+      - name: Install mise-managed toolchain
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          version: stable
+          experimental: true
 
       # ── Setup & Dependencies ────────────────────────────────────────
       - name: Create sample task from template

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,3 @@
-# Foundry version used by the `install-foundry` fallback below. The canonical
-# pin lives in `mise.toml`; please keep this value in sync (commit SHA from
-# `forge --version` on the version pinned in `mise.toml`).
-FOUNDRY_COMMIT ?= b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2
-
 PROJECT_DIR = $(network)/$(shell date +'%Y-%m-%d')-$(task)
 GAS_INCREASE_DIR = $(network)/$(shell date +'%Y-%m-%d')-increase-gas-limit
 GAS_AND_ELASTICITY_INCREASE_DIR = $(network)/$(shell date +'%Y-%m-%d')-increase-gas-and-elasticity-limit
@@ -29,13 +24,6 @@ ifndef $(GOPATH)
     GOPATH=$(shell go env GOPATH)
     export GOPATH
 endif
-
-# Legacy Foundry installer. Prefer `mise install` (see mise.toml and README).
-# This target remains for environments where mise is not available.
-.PHONY: install-foundry
-install-foundry:
-	curl -L https://foundry.paradigm.xyz | bash
-	~/.foundry/bin/foundryup --commit $(FOUNDRY_COMMIT)
 
 ##
 # Project Setup

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-FOUNDRY_COMMIT ?= 3b1129b5bc43ba22a9bcf4e4323c5a9df0023140
+# Foundry version used by the `install-foundry` fallback below. The canonical
+# pin lives in `mise.toml`; please keep this value in sync (commit SHA from
+# `forge --version` on the version pinned in `mise.toml`).
+FOUNDRY_COMMIT ?= b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2
 
 PROJECT_DIR = $(network)/$(shell date +'%Y-%m-%d')-$(task)
 GAS_INCREASE_DIR = $(network)/$(shell date +'%Y-%m-%d')-increase-gas-limit
@@ -27,6 +30,8 @@ ifndef $(GOPATH)
     export GOPATH
 endif
 
+# Legacy Foundry installer. Prefer `mise install` (see mise.toml and README).
+# This target remains for environments where mise is not available.
 .PHONY: install-foundry
 install-foundry:
 	curl -L https://foundry.paradigm.xyz | bash

--- a/README.md
+++ b/README.md
@@ -29,9 +29,40 @@ This repo is structured with each network having a high-level directory which co
 
 ## Setup
 
-First, install forge if you don't have it already:
+### Toolchain (mise)
 
-- Run `make install-foundry` to install [`Foundry`](https://github.com/foundry-rs/foundry/commit/3b1129b5bc43ba22a9bcf4e4323c5a9df0023140).
+All required tooling (Foundry, Node.js, Bun, Go) is pinned in [`mise.toml`](mise.toml) so that every contributor — and especially every signer — runs identical versions. This eliminates a class of bugs where domain separators, build artifacts, or generated signatures differ between machines.
+
+1. Install [`mise`](https://mise.jdx.dev/getting-started.html). On macOS the simplest path is:
+
+   ```bash
+   brew install mise
+   ```
+
+   Then follow the [shell activation instructions](https://mise.jdx.dev/getting-started.html#activate-mise) for your shell (e.g. add `eval "$(mise activate zsh)"` to `~/.zshrc`).
+
+2. From the repo root, install and activate the pinned versions:
+
+   ```bash
+   mise trust    # one-time, approves this repo's mise.toml
+   mise install  # downloads pinned foundry, node, bun, go
+   ```
+
+3. Verify Foundry is on the pinned version (currently `1.5.1`):
+
+   ```bash
+   $ forge --version
+   forge Version: 1.5.1-...
+   Commit SHA: b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2
+   ```
+
+   The `Commit SHA` is the source of truth — it must match the commit pinned in `mise.toml`. The `Version` suffix may differ (`-stable` vs `-v1.5.1`) depending on which release artifact you installed; both are built from the same source.
+
+Once `mise install` has run, `forge`, `cast`, `anvil`, `node`, `npm`, `npx`, `bun`, and `go` will all be on the pinned versions whenever you `cd` into this repo (assuming `mise activate` is set up in your shell).
+
+> **Legacy install:** A `make install-foundry` target is still available for environments where mise cannot be used, but please prefer mise — it keeps all contributors aligned without manual re-pinning.
+
+### Running a task
 
 To execute a new task, run one of the following commands (depending on the type of change you're making):
 
@@ -89,7 +120,7 @@ Templates are validated in parallel using a matrix strategy, so failures are iso
 
 **How it works:**
 
-- Foundry stable is installed via the `foundry-rs/foundry-toolchain` GitHub Action.
+- All tooling (Foundry, Node, Bun, Go) is installed by the [`jdx/mise-action`](https://github.com/jdx/mise-action) GitHub Action using the versions pinned in [`mise.toml`](mise.toml), so CI matches local signer environments.
 - For each template, the corresponding `make setup-*` target creates a task directory from the template.
 - `make deps` installs all dependencies (including base-contracts at the commit pinned in the template's `.env`).
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ All required tooling (Foundry, Node.js, Bun, Go) is pinned in [`mise.toml`](mise
 
 Once `mise install` has run, `forge`, `cast`, `anvil`, `node`, `npm`, `npx`, `bun`, and `go` will all be on the pinned versions whenever you `cd` into this repo (assuming `mise activate` is set up in your shell).
 
-> **Legacy install:** A `make install-foundry` target is still available for environments where mise cannot be used, but please prefer mise — it keeps all contributors aligned without manual re-pinning.
-
 ### Running a task
 
 To execute a new task, run one of the following commands (depending on the type of change you're making):

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,25 @@
+# mise tool versions — https://mise.jdx.dev
+#
+# This file pins the toolchain versions used across the contract-deployments
+# repo. Contributors and signers should install mise and run `mise install` at
+# the repo root so that everyone executes tasks with byte-identical tooling.
+#
+# When bumping any version here, also update the matching pin in
+# `.github/workflows/validate-templates.yml` (or anywhere else CI installs the
+# same tool) so that local and CI runs stay aligned.
+
+[tools]
+# Foundry (forge/cast/anvil/chisel) — pinned for deterministic build artifacts,
+# script outputs, and EIP-712 domain separators across all signers.
+foundry = "1.5.1"
+
+# Node.js — required by the task-signing-tool (`npm ci` / `npx tsx`) and by
+# template scripts that invoke `bun run` against TypeScript sources.
+node = "22.20.0"
+
+# Bun — used by per-task Makefiles to run `scripts/genValidationFile.ts` and
+# other TypeScript helpers shipped with each task.
+bun = "1.3.2"
+
+# Go — required to `go install` the `eip712sign` CLI as part of `make deps`.
+go = "1.25.1"


### PR DESCRIPTION
## Summary

Adds [mise](https://mise.jdx.dev) to pin the toolchain used across the repo. The main motivation is to make sure **every signer is on Foundry `1.5.1`** (commit `b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2`) so build artifacts, EIP-712 domain separators, and generated signatures are byte-identical across machines.

Closes [CHAIN-4496](https://linear.app/coinbase/issue/CHAIN-4496/add-mise-to-contract-deployments-repo-to-standardize-tooling-versions).

## Changes

- **`mise.toml` (new)** — pins:
  - `foundry = "1.5.1"`
  - `node = "22.20.0"` (for `npm ci` / `npx tsx` in the signer-tool)
  - `bun = "1.3.2"` (for `bun run scripts/genValidationFile.ts` in per-task Makefiles)
  - `go = "1.25.1"` (for `go install` of `eip712sign` in `make deps`)
- **`README.md`** — new "Toolchain (mise)" subsection under Setup with install/verify instructions, and updated the CI explainer to point at `jdx/mise-action` + `mise.toml`.
- **`.github/workflows/validate-templates.yml`** — replaces `foundry-rs/foundry-toolchain` with `jdx/mise-action@v4.0.1` (SHA-pinned) so CI uses the same versions as local signers.
- **`Makefile`** — updates `FOUNDRY_COMMIT` to `b0a9dd9...` (v1.5.1) so the legacy `make install-foundry` fallback agrees with `mise.toml`, and adds a comment that `mise.toml` is the canonical pin.

## How signers use it

```bash
brew install mise               # one-time
# activate mise in your shell (see https://mise.jdx.dev/getting-started.html)
mise trust                      # one-time, approves this repo's mise.toml
mise install                    # downloads pinned foundry/node/bun/go
forge --version                 # should show Commit SHA: b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2
```

## Verification

- `mise install` cleanly installs all four tools.
- `mise exec -- forge --version` reports the expected commit SHA `b0a9dd9...`.
- Full CI-equivalent local run against the generic template:
  - `make setup-task network=sepolia task=mise-ci-smoke`
  - `make deps`
  - `forge fmt --check script/` ✓
  - `forge build` ✓ (25 files compiled with Solc 0.8.15, no warnings)