### PR TITLE
Stop baking absolute mise path into validation file cmd field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,21 @@ bootstrap-mise:
 	fi
 	@$(MISE) trust --quiet $(REPO_ROOT)/mise.toml >/dev/null
 	@$(MISE) install --quiet --cd $(REPO_ROOT)
+	@# The signer-tool re-executes the validation file's `cmd` in a fresh shell.
+	@# That command uses bare `mise exec --` (see Multisig.mk GEN_VALIDATION) so
+	@# the validation JSON stays portable across machines. If `mise` is not on
+	@# the user's PATH, that re-execution will fail with "command not found".
+	@if ! command -v mise >/dev/null 2>&1; then \
+		echo ""; \
+		echo "WARNING: 'mise' is installed at $(HOME)/.local/bin/mise but is not on your PATH."; \
+		echo "         The signer-tool needs 'mise' on PATH to re-execute validation file 'cmd' fields."; \
+		echo "         Add this to your shell config (e.g. ~/.zshrc or ~/.bashrc) and restart your shell:"; \
+		echo ""; \
+		echo "             export PATH=\"\$$HOME/.local/bin:\$$PATH\""; \
+		echo ""; \
+		echo "         (Or, for full mise integration: eval \"\$$(mise activate \$$(basename \$$SHELL))\")"; \
+		echo ""; \
+	fi
 
 # Resolve GOPATH lazily via mise so it works after `bootstrap-mise` installs go.
 # Recursive (`=`) expansion defers `go env GOPATH` to recipe time, when mise is

--- a/Multisig.mk
+++ b/Multisig.mk
@@ -45,13 +45,23 @@ endef
 # GEN_VALIDATION: Generate a validation JSON file for multisig signing.
 # $(1)=script_name, $(2)=safe_addr (comma-separated, or empty for []),
 # $(3)=sender, $(4)=output_file, $(5)=env_vars (optional prefix)
+#
+# NOTE: The embedded `--forge-cmd` uses the bare literal `mise exec --` rather
+# than `$(MISE_EXEC)`. The latter expands at Makefile parse time to either
+# `mise exec --` (mise on PATH) or `$(HOME)/.local/bin/mise exec --` (fallback),
+# which would bake a machine-specific absolute path into the generated validation
+# JSON's `cmd` field — and that JSON is committed to the repo and re-hashed at
+# verification time on other machines. By keeping the literal token, the
+# committed file is portable; the trade-off is that `mise` must be discoverable
+# on the signer-tool subprocess's PATH (see the bootstrap-mise warning and the
+# README "Toolchain (mise)" section for the PATH requirement).
 define GEN_VALIDATION
 $(call require_vars,GEN_VALIDATION,RPC_URL LEDGER_ACCOUNT) \
 	cd $(SIGNER_TOOL_PATH) && \
 		$(MISE_EXEC) npx tsx scripts/genValidationFile.ts \
 			--rpc-url $(RPC_URL) \
 			--workdir $(CURDIR) \
-			--forge-cmd '$(if $(5),$(5) )$(MISE_EXEC) forge script --rpc-url $(RPC_URL) $(1) --sig "sign(address[])" "[$(2)]" --sender $(3)' \
+			--forge-cmd '$(if $(5),$(5) )mise exec -- forge script --rpc-url $(RPC_URL) $(1) --sig "sign(address[])" "[$(2)]" --sender $(3)' \
 			--ledger-id $(LEDGER_ACCOUNT) \
 			--out $(CURDIR)/validations/$(4)
 endef

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ All required tooling (Foundry, Node.js, Bun, Go) is pinned in [`mise.toml`](mise
 2. Trusts the repo's `mise.toml` and runs `mise install` to fetch the pinned `foundry`, `node`, `bun`, and `go` versions.
 3. Invokes every toolchain command through `mise exec --`, so the pinned versions are used without modifying your shell environment or `PATH`. This deliberately avoids conflicts with any existing `foundryup` or system-level installs.
 
+> **Important — `mise` must be on your PATH for the signer-tool.** The generated validation files contain a `cmd` field with `mise exec --` (deliberately, so the JSON is portable across machines), and the signer-tool re-executes that command in a fresh shell. If `mise` is not on your PATH, that subprocess will fail with "command not found". `make bootstrap-mise` will warn you if this is the case. To fix it, add this to your shell config (e.g. `~/.zshrc` or `~/.bashrc`) and restart your shell:
+>
+> ```bash
+> export PATH="$HOME/.local/bin:$PATH"
+> ```
+>
+> Alternatively, install `mise` system-wide so it lands on your default PATH.
+
 #### Verifying the pinned Foundry version (optional)
 
 ```bash

--- a/setup-templates/template-set-bridge-partner-threshold/Makefile
+++ b/setup-templates/template-set-bridge-partner-threshold/Makefile
@@ -21,10 +21,15 @@ validate-config:
 	@echo "Configuration validated successfully"
 
 # TODO: ensure `sender` is a signer for `OWNER_SAFE`
+# NOTE: Uses bare literal `mise exec --` (not `$(MISE_EXEC)`) so the forge
+# command written into validations/signer.json by state-diff stays portable
+# across signer machines. See Multisig.mk's GEN_VALIDATION macro for the
+# full rationale and the README's "Toolchain (mise)" section for the PATH
+# requirement on the signer-tool subprocess.
 .PHONY: gen-validation
 gen-validation: validate-config
 	$(GOPATH)/bin/state-diff --rpc $(L1_RPC_URL) -o validations/signer.json \
-	-- $(MISE_EXEC) forge script --rpc-url $(L1_RPC_URL) SetThreshold \
+	-- mise exec -- forge script --rpc-url $(L1_RPC_URL) SetThreshold \
 	--sig "sign(address[])" "[$(OWNER_SAFE)]" \
 	--sender 0xb2d9a52e76841279EF0372c534C539a4f68f8C0B
 


### PR DESCRIPTION
## Problem

PR #704 wrapped toolchain invocations with `$(MISE_EXEC)`, which resolves at Makefile-parse time to either:
- `mise exec --` — when `mise` is on `PATH`, or
- `$(HOME)/.local/bin/mise exec --` — fallback when it is not.

The fallback case bakes a **machine-specific absolute path** into the `cmd` field of every committed validation JSON via:
1. `Multisig.mk`'s `GEN_VALIDATION` macro (used by most current tasks), and
2. `setup-templates/template-set-bridge-partner-threshold/Makefile`'s `gen-validation` target (which writes `validations/signer.json` via `state-diff`).

Both write a forge command into a JSON that is committed to git and hashed by the task-signing-tool at verification time. A validation file generated on machine A (with `$HOME=/Users/alice`) will fail signature verification on machine B (with `$HOME=/Users/bob`). This was discovered while finalising `mainnet/2026-05-27-update-aggregate-verifier` — three task-origin signatures had to be regenerated because the committed validation files contained the original signer's home directory.

The execution macros `MULTISIG_APPROVE` and `MULTISIG_EXECUTE`, and the inline `$(MISE_EXEC)` usages in other templates (`template-gas-increase`, `template-pause-bridge-base`, `template-pause-superchain-config`, `template-upgrade-fault-proofs`, `template-safe-management`), are unaffected because their `$(MISE_EXEC)` is only used inside the `make` recipe shell — nothing is written to disk.

## Fix

1. **`Multisig.mk`**: in `GEN_VALIDATION`'s embedded `--forge-cmd`, replace `$(MISE_EXEC)` with the bare literal `mise exec --`. The generated JSON is now portable across machines. Added a NOTE comment explaining the trade-off.
2. **`setup-templates/template-set-bridge-partner-threshold/Makefile`**: same fix in the template's inline `state-diff` invocation.
3. **`Makefile`**: extend `bootstrap-mise` with a `command -v mise` check that prints a clear warning + remediation when `mise` is installed at `$HOME/.local/bin/mise` but is not on the user's `PATH`. The signer-tool re-executes the validation file's `cmd` in a fresh shell that does not inherit the Makefile's `$(MISE)` resolution, so `mise` must be discoverable via `PATH` for the re-execution to work.
4. **`README.md`**: document the `PATH` requirement in the existing "Toolchain (mise)" section.

## Why keep `mise exec` at all (i.e. why not strip it entirely)?

`mise exec` is what isolates this repo's pinned Foundry/Node/Go versions from any system-level `foundryup` or global toolchain installs. Stripping it would risk version drift between signers. The pattern we want is: the validation file carries the machine-agnostic token `mise exec --`, and each signer's environment ensures `mise` is resolvable.

## Verification

- `make -n bootstrap-mise` parses cleanly.
- The signer-tool subprocess sees `mise exec -- forge script ...` in the generated `cmd`, with no absolute paths.
- Other templates that use `$(MISE_EXEC)` only inside recipe shells (not embedded in JSON output) are intentionally left unchanged.

## Follow-ups

This will be the basis for the two upcoming testnet tasks (Sepolia + Zeronet aggregate-verifier hash updates). Both will inherit the fixed `GEN_VALIDATION` behaviour from `main` once this lands.