### PR TITLE
chore: add sleep between pause signatures

### DIFF
--- a/mainnet/2026-06-02-pause-superchain-config/Makefile
+++ b/mainnet/2026-06-02-pause-superchain-config/Makefile
@@ -36,6 +36,7 @@ sign-pause:
 		sig=$$(grep "^Signature:" sign_output.tmp | awk '{print $$2}'); \
 		printf "%s," "$$signer:$$nonce:$$sig" >> signatures-pause.txt; \
 		rm -f sign_output.tmp; \
+		sleep 2; \
 	done; \
 	echo "" >> signatures-pause.txt
 

--- a/sepolia/2026-06-02-pause-superchain-config/Makefile
+++ b/sepolia/2026-06-02-pause-superchain-config/Makefile
@@ -36,6 +36,7 @@ sign-pause:
 		sig=$$(grep "^Signature:" sign_output.tmp | awk '{print $$2}'); \
 		printf "%s," "$$signer:$$nonce:$$sig" >> signatures-pause.txt; \
 		rm -f sign_output.tmp; \
+		sleep 2; \
 	done; \
 	echo "" >> signatures-pause.txt
 


### PR DESCRIPTION
Adds a brief 2-second delay between Ledger signing attempts in the mainnet and sepolia pause-superchain-config Makefiles so repeated batch signing gives the device time to release and reopen before the next nonce.