### PR TITLE
fix: correct output directory name for setup bridge partner threshold target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GAS_INCREASE_DIR = $(network)/$(shell date +'%Y-%m-%d')-increase-gas-limit
 GAS_AND_ELASTICITY_INCREASE_DIR = $(network)/$(shell date +'%Y-%m-%d')-increase-gas-and-elasticity-limit
 SAFE_MANAGEMENT_DIR = $(network)/$(shell date +'%Y-%m-%d')-safe-management
 FUNDING_DIR = $(network)/$(shell date +'%Y-%m-%d')-funding
-SET_BASE_BRIDGE_PARTNER_THRESHOLD_DIR = $(network)/$(shell date +'%Y-%m-%d')-pause-bridge-base
+SET_BASE_BRIDGE_PARTNER_THRESHOLD_DIR = $(network)/$(shell date +'%Y-%m-%d')-set-bridge-partner-threshold
 PAUSE_BRIDGE_BASE_DIR = $(network)/$(shell date +'%Y-%m-%d')-pause-bridge-base
 PAUSE_SUPERCHAIN_CONFIG_DIR = $(network)/$(shell date +'%Y-%m-%d')-pause-superchain-config
 


### PR DESCRIPTION
ine 11 of Makefile defines the output directory for the setup-bridge-partner-threshold target:

SET_BASE_BRIDGE_PARTNER_THRESHOLD_DIR = $(network)/$(shell date +'%Y-%m-%d')-pause-bridge-base

The `-pause-bridge-base` suffix is a copy-paste error from line 12 (PAUSE_BRIDGE_BASE_DIR). 

Running `make setup-bridge-partner-threshold network=mainnet` creates:
  mainnet/2026-06-13-pause-bridge-base
instead of:
  mainnet/2026-06-13-set-bridge-partner-threshold

This causes:
- Confusion for task creators looking for their generated directory
- Potential directory name collision if a pause-bridge-base task is created on the same day
- Inconsistency with other setup targets whose directory names match their template names

Fix: replace `pause-bridge-base` with `set-bridge-partner-threshold` in the directory pattern.

Closes #732