### PR TITLE
fix: migrate set-bridge-partner-threshold validation to GEN_VALIDATION macro

### DIFF
--- a/setup-templates/template-set-bridge-partner-threshold/.env
+++ b/setup-templates/template-set-bridge-partner-threshold/.env
@@ -8,3 +8,6 @@ L2_BRIDGE_VALIDATOR=
 
 # Required: New partner threshold value (number of signatures required for message validation)
 NEW_THRESHOLD=
+
+# Required: Address of a signer on OWNER_SAFE (used for simulation and validation generation)
+SENDER=

--- a/setup-templates/template-set-bridge-partner-threshold/Makefile
+++ b/setup-templates/template-set-bridge-partner-threshold/Makefile
@@ -18,20 +18,14 @@ validate-config:
 	@test -n "$(L1_PORTAL)" || (echo "L1_PORTAL required" && exit 1)
 	@test -n "$(L2_BRIDGE_VALIDATOR)" || (echo "L2_BRIDGE_VALIDATOR required" && exit 1)
 	@test -n "$(NEW_THRESHOLD)" || (echo "NEW_THRESHOLD required" && exit 1)
+	@test -n "$(SENDER)" || (echo "SENDER required" && exit 1)
 	@echo "Configuration validated successfully"
 
-# TODO: ensure `sender` is a signer for `OWNER_SAFE`
-# NOTE: Uses bare literal `mise exec --` (not `$(MISE_EXEC)`) so the forge
-# command written into validations/signer.json by state-diff stays portable
-# across signer machines. See Multisig.mk's GEN_VALIDATION macro for the
-# full rationale and the README's "Toolchain (mise)" section for the PATH
-# requirement on the signer-tool subprocess.
+# Generate validation file using the signer-tool (GEN_VALIDATION macro from Multisig.mk).
+# Uses $(OWNER_SAFE) as the safe address for forge script simulation.
 .PHONY: gen-validation
-gen-validation: validate-config
-	$(GOPATH)/bin/state-diff --rpc $(L1_RPC_URL) -o validations/signer.json \
-	-- mise exec -- forge script --rpc-url $(L1_RPC_URL) SetThreshold \
-	--sig "sign(address[])" "[$(OWNER_SAFE)]" \
-	--sender 0xb2d9a52e76841279EF0372c534C539a4f68f8C0B
+gen-validation: validate-config deps-signer-tool
+	$(call GEN_VALIDATION,$(SCRIPT_NAME),$(OWNER_SAFE),$(SENDER),base-signer.json,)
 
 # Execute
 .PHONY: execute


### PR DESCRIPTION
## Problem

The `template-set-bridge-partner-threshold/Makefile` uses a **legacy `state-diff` approach** for validation file generation instead of the `GEN_VALIDATION` macro from `Multisig.mk` used by all other templates.

### Issues with the current approach:
- **Hardcoded sender address** (`0xb2d9a52e76841279EF0372c534C539a4f68f8C0B`) instead of reading `$(SENDER)` from `.env`. Rotating signers requires a code change.
- **Missing `deps-signer-tool` dependency** — `state-diff` may not be compiled when `gen-validation` runs.
- **Inconsistent output filename** (`validations/signer.json` vs `validations/base-signer.json`).
- **No `SENDER` env var** defined in the template's `.env` — not validated at all.
- **Bypasses `GEN_VALIDATION`** — misses out on portable `mise exec --` forge-cmd handling (PR #705) and signer-tool version bumps (PR #730).

## Changes

### `setup-templates/template-set-bridge-partner-threshold/.env`
- Added `SENDER` variable (required for signing/validation)

### `setup-templates/template-set-bridge-partner-threshold/Makefile`
- Replaced `$(GOPATH)/bin/state-diff` invocation with `$(call GEN_VALIDATION,...)` macro from `Multisig.mk`
- Added `deps-signer-tool` dependency to `gen-validation`
- Added `SENDER` validation in `validate-config`
- Changed output filename from `validations/signer.json` to `validations/base-signer.json` (consistent with other templates)

This template was left behind when the validation infrastructure was standardized in PR #705 and PR #730. The fix brings it in line with all other templates (`template-funding`, `template-gas-and-elasticity-increase`, `template-safe-management`, `template-pause-bridge-base`).

Closes #732