### PR TITLE
fix: create task origin signature directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,7 @@ SIGNATURE_DIR ?= $(CURDIR)/../signatures/$(TASK_NAME)
 
 .PHONY: sign-as-task-creator
 sign-as-task-creator: deps-signer-tool
+	mkdir -p "$(SIGNATURE_DIR)"
 	cd $(SIGNER_TOOL_PATH) && \
 		$(MISE_EXEC) npx tsx scripts/genTaskOriginSig.ts sign \
 		--task-folder $(CURDIR) \
@@ -181,6 +182,7 @@ sign-as-task-creator: deps-signer-tool
 
 .PHONY: sign-as-base-facilitator
 sign-as-base-facilitator: deps-signer-tool
+	mkdir -p "$(SIGNATURE_DIR)"
 	cd $(SIGNER_TOOL_PATH) && \
 		$(MISE_EXEC) npx tsx scripts/genTaskOriginSig.ts sign \
 		--task-folder $(CURDIR) \
@@ -189,6 +191,7 @@ sign-as-base-facilitator: deps-signer-tool
 
 .PHONY: sign-as-sc-facilitator
 sign-as-sc-facilitator: deps-signer-tool
+	mkdir -p "$(SIGNATURE_DIR)"
 	cd $(SIGNER_TOOL_PATH) && \
 		$(MISE_EXEC) npx tsx scripts/genTaskOriginSig.ts sign \
 		--task-folder $(CURDIR) \


### PR DESCRIPTION
## Summary
- Create `$(SIGNATURE_DIR)` before task-origin signing commands run
- Apply the fix to creator, Base facilitator, and Security Council facilitator signing targets

## Verification
- `git diff --check`
- `make -n sign-as-task-creator` from `mainnet/2026-06-18-beryl` shows `mkdir -p "$(SIGNATURE_DIR)"` before `genTaskOriginSig.ts`
- `make -n sign-as-base-facilitator` from `mainnet/2026-06-18-beryl` shows `mkdir -p "$(SIGNATURE_DIR)"` before `genTaskOriginSig.ts`
- `make -n sign-as-sc-facilitator` from `mainnet/2026-06-18-beryl` shows `mkdir -p "$(SIGNATURE_DIR)"` before `genTaskOriginSig.ts`