### PR TITLE
feat(CHAIN-4635): add mainnet Solana bridge ownership transfer task 

### DIFF
--- a/mainnet/2026-07-09-transfer-solana-bridge-ownership/.env
+++ b/mainnet/2026-07-09-transfer-solana-bridge-ownership/.env
@@ -1,0 +1,34 @@
+BASE_CONTRACTS_COMMIT=be7c7a642e430fa64b04b63203839f8c81f48466
+
+# Must match the sender defined in validations/base-signer.json.
+# Signer: must be an owner EOA of OWNER_SAFE. Facilitator sets this to their own signer
+# address before running `make gen-validation`. Default is the first owner of OWNER_SAFE.
+SENDER=0x6CD3850756b7894774Ab715D136F9dD02837De50
+
+# Old CB L1 multisig (issuer; current owner via its L2 alias).
+OWNER_SAFE=0x9C4a57Feb77e294Fd7BF5EBE9AB01CAA0a90A110
+CURRENT_OWNER_ALIAS=0xaD5B57FEB77e294fD7BF5EBE9aB01caA0a90B221
+
+# New CB L1 multisig (new owner). The script validates its L2 alias via applyL1ToL2Alias.
+NEW_OWNER_SAFE=0x9855054731540A48b28990B63DcF4f33d8AE46A1
+NEW_OWNER_ALIAS=0xa966054731540a48b28990b63Dcf4f33d8aE57B2
+
+# OptimismPortal2 on Ethereum mainnet.
+OPTIMISM_PORTAL_ADDR=0x49048044D57e1C92A77f79988d21Fa8fAF74E97e
+
+# Shared Solady ERC1967Factory (holds the proxy admins). Same address on every chain.
+ERC1967_FACTORY_ADDR=0x0000000000006396FF2a80c067f99B3d2Ab4Df24
+
+# Target contracts on Base mainnet L2.
+BRIDGE_ADDR=0x3eff766C76a1be2Ce1aCF2B69c78bCae257D5188
+TWIN_BEACON_ADDR=0xb326c02150bb0De265Bb0eCeDA53531ab0163bf6
+CROSS_CHAIN_ERC20_BEACON_ADDR=0xddc41fda4b758728d07f4686dbe7d1c75c6b2552
+CROSS_CHAIN_ERC20_FACTORY_ADDR=0xDD56781d0509650f8C2981231B6C917f2d5d7dF2
+BRIDGE_VALIDATOR_ADDR=0xAF24c1c24Ff3BF1e6D882518120fC25442d6794B
+RELAYER_ORCHESTRATOR_ADDR=0x8Cfa6F29930E6310B6074baB0052c14a709B4741
+
+# Gas limit for each L2 deposit transaction.
+L2_GAS_LIMIT=100000
+
+# Required for the task signer tool.
+RECORD_STATE_DIFF=true

--- a/mainnet/2026-07-09-transfer-solana-bridge-ownership/.env
+++ b/mainnet/2026-07-09-transfer-solana-bridge-ownership/.env
@@ -1,6 +1,6 @@
 BASE_CONTRACTS_COMMIT=be7c7a642e430fa64b04b63203839f8c81f48466
 
-# Must match the sender defined in validations/base-signer.json.
+# Must match the sender defined in validations/coinbase-signer.json.
 # Signer: must be an owner EOA of OWNER_SAFE. Facilitator sets this to their own signer
 # address before running `make gen-validation`. Default is the first owner of OWNER_SAFE.
 SENDER=0x6CD3850756b7894774Ab715D136F9dD02837De50

--- a/mainnet/2026-07-09-transfer-solana-bridge-ownership/FACILITATOR.md
+++ b/mainnet/2026-07-09-transfer-solana-bridge-ownership/FACILITATOR.md
@@ -1,0 +1,86 @@
+# Facilitator Guide
+
+Guide for facilitators managing the Base mainnet Solana bridge owner transfer.
+
+## 1. Generate the validation file
+
+Run this after any change to [.env](./.env) or
+[script/TransferSolanaBridgeOwnership.s.sol](./script/TransferSolanaBridgeOwnership.s.sol).
+
+```bash
+cd contract-deployments
+git pull
+cd mainnet/2026-07-09-transfer-solana-bridge-ownership
+make deps
+make gen-validation
+```
+
+This produces `validations/base-signer.json`. Check that the `cmd` field uses:
+
+```text
+--sender 0x6CD3850756b7894774Ab715D136F9dD02837De50
+```
+
+(or whichever owner of `OWNER_SAFE` is set as `SENDER` in `.env`).
+
+### Disable task-origin validation
+
+This task does not ship task-origin signatures. After generating the validation
+file, ensure `validations/base-signer.json` carries the following field at the JSON
+root (add it if the signer-tool did not emit it automatically):
+
+```json
+"skipTaskOriginValidation": true
+```
+
+Commit the file only after that field is set; otherwise signers' UI will demand
+task-origin attestations that do not exist for this task.
+
+## 2. Collect signatures
+
+Ask signers to follow [README.md](./README.md). They run `make sign-task` from the repo root and
+select `mainnet/2026-07-09-transfer-solana-bridge-ownership` in the signing UI. The old multisig
+has a threshold of 3, so collect at least 3 signatures.
+
+## 3. Execute
+
+This task uses direct signatures from `OWNER_SAFE`, so there are no separate nested Safe approval
+transactions. Concatenate the collected signatures and pass them to `make execute`.
+
+```bash
+cd contract-deployments
+git pull
+cd mainnet/2026-07-09-transfer-solana-bridge-ownership
+make deps
+SIGNATURES=AAABBBCCC make execute
+```
+
+Replace `AAABBBCCC` with the concatenated signatures collected from signers.
+
+## 4. Verify onchain
+
+After the L1 deposits are relayed to L2, verify on Base mainnet that every contract is now controlled
+by the new owner alias `0xa966054731540a48b28990b63Dcf4f33d8aE57B2`:
+
+```bash
+export RPC=https://mainnet.base.org
+export FACTORY=0x0000000000006396FF2a80c067f99B3d2Ab4Df24
+
+# Bridge: both the functional owner and the proxy admin must move.
+cast call 0x3eff766C76a1be2Ce1aCF2B69c78bCae257D5188 "owner()(address)" --rpc-url $RPC
+cast call $FACTORY "adminOf(address)(address)" 0x3eff766C76a1be2Ce1aCF2B69c78bCae257D5188 --rpc-url $RPC
+
+# Beacons.
+cast call 0xb326c02150bb0De265Bb0eCeDA53531ab0163bf6 "owner()(address)" --rpc-url $RPC
+cast call 0xddc41fda4b758728d07f4686dbe7d1c75c6b2552 "owner()(address)" --rpc-url $RPC
+
+# Proxies (admin held in the factory).
+cast call $FACTORY "adminOf(address)(address)" 0xDD56781d0509650f8C2981231B6C917f2d5d7dF2 --rpc-url $RPC
+cast call $FACTORY "adminOf(address)(address)" 0xAF24c1c24Ff3BF1e6D882518120fC25442d6794B --rpc-url $RPC
+cast call $FACTORY "adminOf(address)(address)" 0x8Cfa6F29930E6310B6074baB0052c14a709B4741 --rpc-url $RPC
+```
+
+Each call must return `0xa966054731540a48b28990b63Dcf4f33d8aE57B2`.
+
+Then update [README.md](./README.md) status to `EXECUTED` with the transaction link and check in any
+generated execution records.

--- a/mainnet/2026-07-09-transfer-solana-bridge-ownership/FACILITATOR.md
+++ b/mainnet/2026-07-09-transfer-solana-bridge-ownership/FACILITATOR.md
@@ -15,7 +15,7 @@ make deps
 make gen-validation
 ```
 
-This produces `validations/base-signer.json`. Check that the `cmd` field uses:
+This produces `validations/coinbase-signer.json`. Check that the `cmd` field uses:
 
 ```text
 --sender 0x6CD3850756b7894774Ab715D136F9dD02837De50
@@ -26,14 +26,15 @@ This produces `validations/base-signer.json`. Check that the `cmd` field uses:
 ### Disable task-origin validation
 
 This task does not ship task-origin signatures. After generating the validation
-file, ensure `validations/base-signer.json` carries the following field at the JSON
-root (add it if the signer-tool did not emit it automatically):
+file, ensure `validations/coinbase-signer.json` carries the following fields at the
+JSON root (add them if the signer-tool did not emit them automatically):
 
 ```json
-"skipTaskOriginValidation": true
+"skipTaskOriginValidation": true,
+"hideTaskOriginSkippedPage": true
 ```
 
-Commit the file only after that field is set; otherwise signers' UI will demand
+Commit the file only after those fields are set; otherwise signers' UI will demand
 task-origin attestations that do not exist for this task.
 
 ## 2. Collect signatures

--- a/mainnet/2026-07-09-transfer-solana-bridge-ownership/Makefile
+++ b/mainnet/2026-07-09-transfer-solana-bridge-ownership/Makefile
@@ -1,0 +1,15 @@
+include ../../Makefile
+include ../../Multisig.mk
+include ../.env
+include .env
+
+RPC_URL = $(L1_RPC_URL)
+SCRIPT_NAME = TransferSolanaBridgeOwnership
+
+.PHONY: gen-validation
+gen-validation: deps-signer-tool
+	$(call GEN_VALIDATION,$(SCRIPT_NAME),,$(SENDER),base-signer.json,)
+
+.PHONY: execute
+execute:
+	$(call MULTISIG_EXECUTE,$(SIGNATURES))

--- a/mainnet/2026-07-09-transfer-solana-bridge-ownership/Makefile
+++ b/mainnet/2026-07-09-transfer-solana-bridge-ownership/Makefile
@@ -8,7 +8,7 @@ SCRIPT_NAME = TransferSolanaBridgeOwnership
 
 .PHONY: gen-validation
 gen-validation: deps-signer-tool
-	$(call GEN_VALIDATION,$(SCRIPT_NAME),,$(SENDER),base-signer.json,)
+	$(call GEN_VALIDATION,$(SCRIPT_NAME),,$(SENDER),coinbase-signer.json,)
 
 .PHONY: execute
 execute:

--- a/mainnet/2026-07-09-transfer-solana-bridge-ownership/README.md
+++ b/mainnet/2026-07-09-transfer-solana-bridge-ownership/README.md
@@ -1,0 +1,57 @@
+# Transfer Base Mainnet Solana Bridge Owner
+
+Status: `READY TO SIGN`
+
+## Description
+
+This task transfers control of the Base mainnet Solana bridge contracts from the aliased old
+Coinbase L1 multisig to the aliased new Coinbase L1 multisig.
+
+Superchain separation migrated Coinbase upgrade signers to a new multisig address, but these bridge
+contracts are still controlled by the old multisig's L2 alias.
+
+| Role | L1 address | L2 alias |
+| -- | -- | -- |
+| Current owner | [`0x9C4a57Feb77e294Fd7BF5EBE9AB01CAA0a90A110`](https://etherscan.io/address/0x9C4a57Feb77e294Fd7BF5EBE9AB01CAA0a90A110) | [`0xaD5B57FEB77e294fD7BF5EBE9aB01caA0a90B221`](https://basescan.org/address/0xaD5B57FEB77e294fD7BF5EBE9aB01caA0a90B221) |
+| New owner | [`0x9855054731540A48b28990B63DcF4f33d8AE46A1`](https://etherscan.io/address/0x9855054731540A48b28990B63DcF4f33d8AE46A1) | [`0xa966054731540a48b28990b63Dcf4f33d8aE57B2`](https://basescan.org/address/0xa966054731540a48b28990b63Dcf4f33d8aE57B2) |
+
+The calls are executed from Ethereum mainnet through `OptimismPortal2`, which makes the old L1
+multisig's aliased address transfer ownership of each contract on Base. Two ownership mechanisms are
+involved:
+
+| Contract | Address | Mechanism |
+| -- | -- | -- |
+| Bridge | [`0x3eff766C76a1be2Ce1aCF2B69c78bCae257D5188`](https://basescan.org/address/0x3eff766C76a1be2Ce1aCF2B69c78bCae257D5188) | `transferOwnership` + `ERC1967Factory.changeAdmin` |
+| TwinBeacon | [`0xb326c02150bb0De265Bb0eCeDA53531ab0163bf6`](https://basescan.org/address/0xb326c02150bb0De265Bb0eCeDA53531ab0163bf6) | `transferOwnership` |
+| CrossChainERC20Beacon | [`0xddc41fda4b758728d07f4686dbe7d1c75c6b2552`](https://basescan.org/address/0xddc41fda4b758728d07f4686dbe7d1c75c6b2552) | `transferOwnership` |
+| CrossChainERC20Factory | [`0xDD56781d0509650f8C2981231B6C917f2d5d7dF2`](https://basescan.org/address/0xDD56781d0509650f8C2981231B6C917f2d5d7dF2) | `ERC1967Factory.changeAdmin` |
+| BridgeValidator | [`0xAF24c1c24Ff3BF1e6D882518120fC25442d6794B`](https://basescan.org/address/0xAF24c1c24Ff3BF1e6D882518120fC25442d6794B) | `ERC1967Factory.changeAdmin` |
+| RelayerOrchestrator | [`0x8Cfa6F29930E6310B6074baB0052c14a709B4741`](https://basescan.org/address/0x8Cfa6F29930E6310B6074baB0052c14a709B4741) | `ERC1967Factory.changeAdmin` |
+
+## Approving the transaction
+
+### 1. Update repo
+
+```bash
+cd contract-deployments
+git pull
+```
+
+### 2. Run the signing tool
+
+Run this command from the repo root. Do not enter the task directory.
+
+```bash
+make sign-task
+```
+
+### 3. Sign
+
+Open [http://localhost:3000](http://localhost:3000) and select:
+
+```text
+mainnet/2026-07-09-transfer-solana-bridge-ownership
+```
+
+After signing, copy the signature and send it to the facilitator. You may then close the signer
+tool with `Ctrl + C`.

--- a/mainnet/2026-07-09-transfer-solana-bridge-ownership/foundry.toml
+++ b/mainnet/2026-07-09-transfer-solana-bridge-ownership/foundry.toml
@@ -1,0 +1,22 @@
+[profile.default]
+src = 'src'
+out = 'out'
+libs = ['lib']
+broadcast = 'records'
+fs_permissions = [{ access = "read-write", path = "./" }]
+optimizer = true
+optimizer_runs = 999999
+solc_version = "0.8.15"
+via-ir = false
+evm_version = "shanghai"
+remappings = [
+    '@base-contracts/=lib/contracts',
+    '@lib-keccak/=lib/lib-keccak/contracts/lib/',
+    '@solady/=lib/solady/src/',
+    'src/=lib/contracts/src/'
+]
+
+[lint]
+lint_on_build = false
+
+# See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/mainnet/2026-07-09-transfer-solana-bridge-ownership/script/TransferSolanaBridgeOwnership.s.sol
+++ b/mainnet/2026-07-09-transfer-solana-bridge-ownership/script/TransferSolanaBridgeOwnership.s.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {Vm} from "forge-std/Vm.sol";
+
+import {MultisigScript, Enum} from "@base-contracts/script/universal/MultisigScript.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
+import {IOptimismPortal2} from "@base-contracts/interfaces/L1/IOptimismPortal2.sol";
+import {AddressAliasHelper} from "@base-contracts/src/vendor/AddressAliasHelper.sol";
+
+/// @notice Minimal interface for Solady Ownable / OwnableRoles / UpgradeableBeacon ownership transfer.
+interface IOwnable {
+    function transferOwnership(address newOwner) external;
+}
+
+/// @notice Minimal interface for the shared Solady ERC1967Factory proxy-admin transfer.
+interface IERC1967Factory {
+    function changeAdmin(address proxy, address admin) external;
+}
+
+/// @title TransferSolanaBridgeOwnership
+/// @notice Transfers ownership/admin of the Base mainnet Solana bridge contracts from the alias of
+///         the old Coinbase L1 multisig to the alias of the new Coinbase L1 multisig.
+contract TransferSolanaBridgeOwnership is MultisigScript {
+    using AddressAliasHelper for address;
+
+    /// @notice L1 Safe that currently owns the bridge contracts through its L2 alias.
+    address public immutable OWNER_SAFE = vm.envAddress("OWNER_SAFE");
+
+    /// @notice L1 Safe that should own the bridge contracts through its L2 alias.
+    address public immutable NEW_OWNER_SAFE = vm.envAddress("NEW_OWNER_SAFE");
+
+    /// @notice Expected L2 alias of OWNER_SAFE.
+    address public immutable CURRENT_OWNER_ALIAS = vm.envAddress("CURRENT_OWNER_ALIAS");
+
+    /// @notice Expected L2 alias of NEW_OWNER_SAFE.
+    address public immutable NEW_OWNER_ALIAS = vm.envAddress("NEW_OWNER_ALIAS");
+
+    /// @notice OptimismPortal2 contract on L1 used for deposit transactions.
+    address public immutable OPTIMISM_PORTAL = vm.envAddress("OPTIMISM_PORTAL_ADDR");
+
+    /// @notice Shared Solady ERC1967Factory that holds proxy admins.
+    address public immutable ERC1967_FACTORY = vm.envAddress("ERC1967_FACTORY_ADDR");
+
+    /// @notice Solana bridge proxy on Base mainnet L2.
+    address public immutable BRIDGE = vm.envAddress("BRIDGE_ADDR");
+
+    /// @notice Twin UpgradeableBeacon on Base mainnet L2.
+    address public immutable TWIN_BEACON = vm.envAddress("TWIN_BEACON_ADDR");
+
+    /// @notice CrossChainERC20 UpgradeableBeacon on Base mainnet L2.
+    address public immutable CROSS_CHAIN_ERC20_BEACON = vm.envAddress("CROSS_CHAIN_ERC20_BEACON_ADDR");
+
+    /// @notice CrossChainERC20Factory proxy on Base mainnet L2.
+    address public immutable CROSS_CHAIN_ERC20_FACTORY = vm.envAddress("CROSS_CHAIN_ERC20_FACTORY_ADDR");
+
+    /// @notice BridgeValidator proxy on Base mainnet L2.
+    address public immutable BRIDGE_VALIDATOR = vm.envAddress("BRIDGE_VALIDATOR_ADDR");
+
+    /// @notice RelayerOrchestrator proxy on Base mainnet L2.
+    address public immutable RELAYER_ORCHESTRATOR = vm.envAddress("RELAYER_ORCHESTRATOR_ADDR");
+
+    /// @notice Gas limit for each L2 deposit transaction.
+    uint64 public immutable L2_GAS_LIMIT;
+
+    constructor() {
+        uint256 gasLimit = vm.envUint("L2_GAS_LIMIT");
+        require(gasLimit <= type(uint64).max, "TransferSolanaBridgeOwnership: L2_GAS_LIMIT too large");
+        L2_GAS_LIMIT = uint64(gasLimit);
+
+        require(
+            OWNER_SAFE.applyL1ToL2Alias() == CURRENT_OWNER_ALIAS,
+            "TransferSolanaBridgeOwnership: incorrect current owner alias"
+        );
+        require(
+            NEW_OWNER_SAFE.applyL1ToL2Alias() == NEW_OWNER_ALIAS,
+            "TransferSolanaBridgeOwnership: incorrect new owner alias"
+        );
+    }
+
+    /// @notice Post-check is a no-op because the L1 simulation cannot verify post-deposit L2 state.
+    function _postCheck(Vm.AccountAccess[] memory, Simulation.Payload memory) internal override {}
+
+    /// @notice Builds the L1 deposit transactions that transfer ownership of each bridge contract on L2.
+    /// @dev Each deposit targets the contract (or the ERC1967Factory) directly rather than routing
+    ///      through an L2 CBMulticall, so that the L2 msg.sender is the owner safe's alias and the
+    ///      onlyOwner / adminOf checks pass.
+    function _buildCalls() internal view override returns (Call[] memory) {
+        Call[] memory calls = new Call[](7);
+
+        bytes memory transferOwnerCalldata = abi.encodeCall(IOwnable.transferOwnership, (NEW_OWNER_ALIAS));
+
+        // Bridge: OwnableRoles functional owner + ERC1967 proxy admin (both currently the old alias).
+        calls[0] = _deposit({l2Target: BRIDGE, l2Calldata: transferOwnerCalldata});
+        calls[1] = _deposit({
+            l2Target: ERC1967_FACTORY,
+            l2Calldata: abi.encodeCall(IERC1967Factory.changeAdmin, (BRIDGE, NEW_OWNER_ALIAS))
+        });
+
+        // Beacons: Solady UpgradeableBeacon owner.
+        calls[2] = _deposit({l2Target: TWIN_BEACON, l2Calldata: transferOwnerCalldata});
+        calls[3] = _deposit({l2Target: CROSS_CHAIN_ERC20_BEACON, l2Calldata: transferOwnerCalldata});
+
+        // Proxies with no Ownable owner: ERC1967 proxy admin only.
+        calls[4] = _deposit({
+            l2Target: ERC1967_FACTORY,
+            l2Calldata: abi.encodeCall(IERC1967Factory.changeAdmin, (CROSS_CHAIN_ERC20_FACTORY, NEW_OWNER_ALIAS))
+        });
+        calls[5] = _deposit({
+            l2Target: ERC1967_FACTORY,
+            l2Calldata: abi.encodeCall(IERC1967Factory.changeAdmin, (BRIDGE_VALIDATOR, NEW_OWNER_ALIAS))
+        });
+        calls[6] = _deposit({
+            l2Target: ERC1967_FACTORY,
+            l2Calldata: abi.encodeCall(IERC1967Factory.changeAdmin, (RELAYER_ORCHESTRATOR, NEW_OWNER_ALIAS))
+        });
+
+        return calls;
+    }
+
+    /// @notice Wraps an L2 call into an L1 OptimismPortal deposit transaction.
+    function _deposit(address l2Target, bytes memory l2Calldata) internal view returns (Call memory) {
+        return Call({
+            operation: Enum.Operation.Call,
+            target: OPTIMISM_PORTAL,
+            data: abi.encodeCall(IOptimismPortal2.depositTransaction, (l2Target, 0, L2_GAS_LIMIT, false, l2Calldata)),
+            value: 0
+        });
+    }
+
+    function _ownerSafe() internal view override returns (address) {
+        return OWNER_SAFE;
+    }
+}

--- a/mainnet/2026-07-09-transfer-solana-bridge-ownership/validations/base-signer.json
+++ b/mainnet/2026-07-09-transfer-solana-bridge-ownership/validations/base-signer.json
@@ -1,0 +1,60 @@
+{
+  "cmd": "mise exec -- forge script --rpc-url https://eth-mainnet.public.blastapi.io TransferSolanaBridgeOwnership --sig sign(address[]) [] --sender 0x6CD3850756b7894774Ab715D136F9dD02837De50",
+  "ledgerId": 0,
+  "rpcUrl": "https://eth-mainnet.public.blastapi.io",
+  "expectedDomainAndMessageHashes": {
+    "address": "0x9C4a57Feb77e294Fd7BF5EBE9AB01CAA0a90A110",
+    "domainHash": "0xfb308368b8deca582e84a807d31c1bfcec6fda754061e2801b4d6be5cb52a8ac",
+    "messageHash": "0xe13b8a3f926de8839ff800d678612725b18d03d9c3c7bcccd5fa7883fbb6487b"
+  },
+  "stateOverrides": [
+    {
+      "name": "CB Signer Safe - Mainnet",
+      "address": "0x9C4a57Feb77e294Fd7BF5EBE9AB01CAA0a90A110",
+      "overrides": [
+        {
+          "key": "0x0000000000000000000000000000000000000000000000000000000000000004",
+          "value": "0x0000000000000000000000000000000000000000000000000000000000000001",
+          "description": "Override the threshold to 1 so the transaction simulation can occur.",
+          "allowDifference": false
+        },
+        {
+          "key": "0x15fa6a97a8b47cea4cbdb0d160362d5c9bc1b8b700f4cb9cd39dec0c5015939f",
+          "value": "0x0000000000000000000000000000000000000000000000000000000000000001",
+          "description": "Simulates an approval from msg.sender in order for the task simulation to succeed.",
+          "allowDifference": false
+        }
+      ]
+    }
+  ],
+  "stateChanges": [
+    {
+      "name": "OptimismPortal - Mainnet",
+      "address": "0x49048044D57e1C92A77f79988d21Fa8fAF74E97e",
+      "changes": [
+        {
+          "key": "0x0000000000000000000000000000000000000000000000000000000000000001",
+          "before": "0x0000000001850c070000000000179e620000000000000000000000003b9aca00",
+          "after": "0x0000000001850c0800000000000aae600000000000000000000000003b9aca00",
+          "description": "Updates the ResourceMetering parameters (prevBlockNum, prevBoughtGas, prevBaseFee).",
+          "allowDifference": true
+        }
+      ]
+    },
+    {
+      "name": "CB Signer Safe - Mainnet",
+      "address": "0x9C4a57Feb77e294Fd7BF5EBE9AB01CAA0a90A110",
+      "changes": [
+        {
+          "key": "0x0000000000000000000000000000000000000000000000000000000000000005",
+          "before": "0x000000000000000000000000000000000000000000000000000000000000000b",
+          "after": "0x000000000000000000000000000000000000000000000000000000000000000c",
+          "description": "Increments the nonce",
+          "allowDifference": false
+        }
+      ]
+    }
+  ],
+  "balanceChanges": [],
+  "skipTaskOriginValidation": true
+}

--- a/mainnet/2026-07-09-transfer-solana-bridge-ownership/validations/coinbase-signer.json
+++ b/mainnet/2026-07-09-transfer-solana-bridge-ownership/validations/coinbase-signer.json
@@ -56,5 +56,6 @@
     }
   ],
   "balanceChanges": [],
-  "skipTaskOriginValidation": true
+  "skipTaskOriginValidation": true,
+  "hideTaskOriginSkippedPage": true
 }


### PR DESCRIPTION
## Summary
- Adds `mainnet/2026-07-09-transfer-solana-bridge-ownership` to transfer Base mainnet Solana bridge ownership/admin from the old CB L1 Safe alias to the new one via 7 OptimismPortal deposits
- Mirrors the Sepolia bridge ownership transfer ([#745](https://github.com/base/contract-deployments/pull/745) / CHAIN-4636) and FeeDisburser mainnet pattern (CHAIN-4519)
- Includes `validations/base-signer.json` with `skipTaskOriginValidation: true` (single CB Safe signing; no nested SC approval)

Made with [Cursor](https://cursor.com)