### PR TITLE
fix: correct output directory name for setup-bridge-partner-threshold target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GAS_INCREASE_DIR = $(network)/$(shell date +'%Y-%m-%d')-increase-gas-limit
 GAS_AND_ELASTICITY_INCREASE_DIR = $(network)/$(shell date +'%Y-%m-%d')-increase-gas-and-elasticity-limit
 SAFE_MANAGEMENT_DIR = $(network)/$(shell date +'%Y-%m-%d')-safe-management
 FUNDING_DIR = $(network)/$(shell date +'%Y-%m-%d')-funding
-SET_BASE_BRIDGE_PARTNER_THRESHOLD_DIR = $(network)/$(shell date +'%Y-%m-%d')-pause-bridge-base
+SET_BASE_BRIDGE_PARTNER_THRESHOLD_DIR = $(network)/$(shell date +'%Y-%m-%d')-set-bridge-partner-threshold
 PAUSE_BRIDGE_BASE_DIR = $(network)/$(shell date +'%Y-%m-%d')-pause-bridge-base
 PAUSE_SUPERCHAIN_CONFIG_DIR = $(network)/$(shell date +'%Y-%m-%d')-pause-superchain-config
 


### PR DESCRIPTION
Fixes #732

## What changed?

`SET_BASE_BRIDGE_PARTNER_THRESHOLD_DIR` on line 11 of the root Makefile produced directories named `<network>/<date>-pause-bridge-base` — a copy-paste of `PAUSE_BRIDGE_BASE_DIR` on the line below. It now produces `<network>/<date>-set-bridge-partner-threshold`, consistent with the template name (`template-set-bridge-partner-threshold`) and the other setup targets.

## Why?

Running `make setup-bridge-partner-threshold network=<network>` scaffolds the task under the wrong name, and — since `PAUSE_BRIDGE_BASE_DIR` expands to the identical path — a same-day `make setup-pause-bridge-base` would land in the same directory and mix the two tasks' files. The repo contains no `*-set-bridge-partner-threshold` task directory to date, so every use of this target has required manual renaming.

## How has it been tested?

Ran `make setup-bridge-partner-threshold network=sepolia` on this branch: it now creates `sepolia/<date>-set-bridge-partner-threshold` and `sepolia/signatures/<date>-set-bridge-partner-threshold` as expected (test artifacts removed before commit).