### PR TITLE
feat(active-evm): add shared Foundry project and common scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ setup-superchain-config-pause:
 # Pinned tag for openzeppelin-contracts-upgradeable, installed via clone-oz-upgradeable.
 OZ_UPGRADEABLE_TAG=v4.7.3
 LIB_KECCAK_COMMIT=3b1e7bbb4cc23e9228097cfebe42aedaf3b8f2b9
+PROJECT_DIR ?= $(CURDIR)
 
 .PHONY: deps
 deps: bootstrap-mise install-eip712sign clean-lib forge-deps
@@ -128,12 +129,12 @@ install-eip712sign:
 
 .PHONY: clean-lib
 clean-lib:
-	rm -rf lib
+	rm -rf $(PROJECT_DIR)/lib
 
 .PHONY: forge-deps
 forge-deps:
 	[ -n "$(BASE_CONTRACTS_COMMIT)" ] || (echo "BASE_CONTRACTS_COMMIT must be set in .env" && exit 1)
-	$(MISE_EXEC) forge install --no-git github.com/foundry-rs/forge-std@0844d7e1fc5e60d77b68e469bff60265f236c398 \
+	cd $(PROJECT_DIR) && $(MISE_EXEC) forge install --no-git github.com/foundry-rs/forge-std@0844d7e1fc5e60d77b68e469bff60265f236c398 \
 	github.com/Vectorized/solady@502cc1ea718e6fa73b380635ee0868b0740595f0 \
 	github.com/ethereum-optimism/lib-keccak@$(LIB_KECCAK_COMMIT) \
 	github.com/base/contracts@$(BASE_CONTRACTS_COMMIT)
@@ -141,7 +142,7 @@ forge-deps:
 ##
 # Task Signer Tool
 ##
-SIGNER_TOOL_COMMIT=8b50397aa06533e2ccbad1fe8b0694367177d87f
+SIGNER_TOOL_COMMIT=566102238bc78fb023f495372d6f80282efa05dd
 SIGNER_TOOL_PATH=signer-tool
 
 .PHONY: checkout-signer-tool
@@ -167,9 +168,10 @@ sign-task: bootstrap-mise checkout-signer-tool
 	$(MISE_EXEC) npm run dev
 
 # Task origin signature variables (auto-derived, overridable).
-# These targets are designed to be invoked from task subdirectories
-# (e.g. sepolia/2026-02-19-superchain-separation/) that include this Makefile.
+# Legacy task subdirectories sign their own folder by default. Active EVM tasks
+# override TASK_ORIGIN_DIR to sign active/evm/tasks/<task-id>/config/<network>.
 TASK_NAME ?= $(notdir $(CURDIR))
+TASK_ORIGIN_DIR ?= $(CURDIR)
 SIGNATURE_DIR ?= $(CURDIR)/../signatures/$(TASK_NAME)
 
 .PHONY: sign-as-task-creator
@@ -177,16 +179,16 @@ sign-as-task-creator: deps-signer-tool
 	mkdir -p "$(SIGNATURE_DIR)"
 	cd $(SIGNER_TOOL_PATH) && \
 		$(MISE_EXEC) npx tsx scripts/genTaskOriginSig.ts sign \
-		--task-folder $(CURDIR) \
-		--signature-path $(SIGNATURE_DIR)
+		--task-folder "$(TASK_ORIGIN_DIR)" \
+		--signature-path "$(SIGNATURE_DIR)"
 
 .PHONY: sign-as-base-facilitator
 sign-as-base-facilitator: deps-signer-tool
 	mkdir -p "$(SIGNATURE_DIR)"
 	cd $(SIGNER_TOOL_PATH) && \
 		$(MISE_EXEC) npx tsx scripts/genTaskOriginSig.ts sign \
-		--task-folder $(CURDIR) \
-		--signature-path $(SIGNATURE_DIR) \
+		--task-folder "$(TASK_ORIGIN_DIR)" \
+		--signature-path "$(SIGNATURE_DIR)" \
 		--facilitator base
 
 .PHONY: sign-as-sc-facilitator
@@ -194,6 +196,6 @@ sign-as-sc-facilitator: deps-signer-tool
 	mkdir -p "$(SIGNATURE_DIR)"
 	cd $(SIGNER_TOOL_PATH) && \
 		$(MISE_EXEC) npx tsx scripts/genTaskOriginSig.ts sign \
-		--task-folder $(CURDIR) \
-		--signature-path $(SIGNATURE_DIR) \
+		--task-folder "$(TASK_ORIGIN_DIR)" \
+		--signature-path "$(SIGNATURE_DIR)" \
 		--facilitator security-council

--- a/Multisig.mk
+++ b/Multisig.mk
@@ -55,6 +55,8 @@ endef
 # committed file is portable; the trade-off is that `mise` must be discoverable
 # on the signer-tool subprocess's PATH (see the bootstrap-mise warning and the
 # README "Toolchain (mise)" section for the PATH requirement).
+VALIDATIONS_DIR ?= $(CURDIR)/validations
+
 define GEN_VALIDATION
 $(call require_vars,GEN_VALIDATION,RPC_URL LEDGER_ACCOUNT) \
 	cd $(SIGNER_TOOL_PATH) && \
@@ -63,7 +65,7 @@ $(call require_vars,GEN_VALIDATION,RPC_URL LEDGER_ACCOUNT) \
 			--workdir $(CURDIR) \
 			--forge-cmd '$(if $(5),$(5) )mise exec -- forge script --rpc-url $(RPC_URL) $(1) --sig "sign(address[])" "[$(2)]" --sender $(3)' \
 			--ledger-id $(LEDGER_ACCOUNT) \
-			--out $(CURDIR)/validations/$(4)
+			--out $(VALIDATIONS_DIR)/$(4)
 endef
 
 # ---------- Helpers ----------

--- a/active/evm/foundry.toml
+++ b/active/evm/foundry.toml
@@ -1,0 +1,22 @@
+[profile.default]
+src = 'src'
+out = 'out'
+libs = ['lib']
+broadcast = 'records'
+fs_permissions = [{ access = "read-write", path = "./" }]
+optimizer = true
+optimizer_runs = 200
+auto_detect_solc = true
+evm_version = "prague"
+via-ir = false
+remappings = [
+    '@base-contracts/=lib/contracts/',
+    'forge-std/=lib/forge-std/src/',
+    'interfaces/L1/=lib/contracts/interfaces/L1/',
+    'interfaces/legacy/=lib/contracts/interfaces/legacy/',
+    'interfaces/universal/=lib/contracts/interfaces/universal/',
+    'src/libraries/=lib/contracts/src/libraries/',
+]
+
+[lint]
+lint_on_build = false

--- a/active/evm/script/common/README.md
+++ b/active/evm/script/common/README.md
@@ -1,0 +1,39 @@
+# Common EVM Scripts
+
+Reusable EVM operation scripts live here. A script belongs in this directory when it is expected to be reused across tasks, networks, or task templates. Keep one-off task glue outside this directory.
+
+## How To Use
+
+Reference common scripts by explicit Forge target path from `active/evm`:
+
+```bash
+mise exec -- forge script --rpc-url "$L1_RPC_URL" script/common/verifier-update/UpdateVerifierHashes.s.sol:UpdateVerifierHashes
+```
+
+In Makefiles, prefer the same explicit path:
+
+```makefile
+SCRIPT_NAME = script/common/verifier-update/UpdateVerifierHashes.s.sol:UpdateVerifierHashes
+```
+
+This keeps validation JSON portable and avoids ambiguity when different files define similarly named contracts.
+
+## Script Inventory
+
+| Folder | Script | Purpose | Required task files |
+| --- | --- | --- | --- |
+| `verifier-update/` | `DeployAggregateVerifier.s.sol` | Deploys a replacement `AggregateVerifier` by copying immutable constructor inputs from the live implementation and replacing verifier hashes. | `tasks/<task-id>/config/<network>/.env`, `tasks/<task-id>/config/<network>/network.env`, `ADDRESSES_JSON` output path |
+| `verifier-update/` | `UpdateVerifierHashes.s.sol` | Multisig script that updates `DisputeGameFactory.gameImpls(gameType)` to a deployed `AggregateVerifier`. | `ADDRESSES_JSON` pointing at a JSON file with `aggregateVerifier` |
+| `funding/` | `Fund.s.sol` | Sends native token from a Safe to recipients listed in `funding.json`. | `funding.json` |
+| `gas/` | `IncreaseEip1559ElasticityAndIncreaseGasLimit.s.sol` | Updates gas limit, EIP-1559 elasticity, and DA footprint gas scalar on `SystemConfig`. | config env values |
+| `bridge/` | `PauseBridge.s.sol` | Deposits an L2 transaction through the portal to pause or unpause the L2 bridge. | config env values |
+| `bridge/` | `SetThreshold.s.sol` | Deposits an L2 transaction through the portal to update bridge partner threshold. | config env values |
+| `superchain/` | `PauseSuperchainConfig.s.sol` | Pauses the chain through `SuperchainConfig`. | config env values |
+| `safe/` | `UpdateSigners.s.sol` | Adds and removes Safe owners while preserving threshold. | `OwnerDiff.json` |
+| `ownership/` | `TransferSystemConfigOwnership.s.sol` | Multisig script that transfers `SystemConfig` ownership from the current owner to a new owner. | `PROXY_ADMIN_OWNER`, `INCIDENT_MULTISIG`, `SYSTEM_CONFIG` env values |
+
+## Adding Scripts
+
+Use exact Solidity pragmas based on the contracts the script imports; preserve a script's original exact pragma when moving it here. Load config from environment variables into immutable variables where possible. Keep task-specific values in `tasks/<task-id>/config/<network>/.env`, `tasks/<task-id>/config/<network>/network.env`, or task-local JSON files rather than hardcoding them in common scripts.
+
+If a script needs task-specific behavior, prefer a small task-local wrapper or Makefile target that passes environment variables into a common script. Move the underlying Solidity into this directory only when the operation itself is reusable.

--- a/active/evm/script/common/bridge/PauseBridge.s.sol
+++ b/active/evm/script/common/bridge/PauseBridge.s.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {Vm} from "forge-std/Vm.sol";
+
+import {Simulation} from "@base-contracts/scripts/universal/Simulation.sol";
+import {MultisigScript, Enum} from "@base-contracts/scripts/universal/MultisigScript.sol";
+
+interface IOptimismPortal2 {
+    function depositTransaction(address _to, uint256 _value, uint64 _gasLimit, bool _isCreation, bytes memory _data)
+        external
+        payable;
+}
+
+interface IBridge {
+    function setPaused(bool) external;
+}
+
+contract PauseBridge is MultisigScript {
+    address public immutable OWNER_SAFE = vm.envAddress("OWNER_SAFE");
+    address public immutable L1_PORTAL = vm.envAddress("L1_PORTAL");
+    address public immutable L2_BRIDGE = vm.envAddress("L2_BRIDGE");
+    bool public immutable IS_PAUSED = vm.envBool("IS_PAUSED");
+
+    function _buildCalls() internal view override returns (Call[] memory) {
+        Call[] memory calls = new Call[](1);
+
+        address to = L2_BRIDGE;
+        uint256 value = 0;
+        uint64 gasLimit = 100_000;
+        bool isCreation = false;
+        bytes memory data = abi.encodeCall(IBridge.setPaused, (IS_PAUSED));
+
+        calls[0] = Call({
+            operation: Enum.Operation.Call,
+            target: L1_PORTAL,
+            data: abi.encodeCall(IOptimismPortal2.depositTransaction, (to, value, gasLimit, isCreation, data)),
+            value: value
+        });
+
+        return calls;
+    }
+
+    function _postCheck(Vm.AccountAccess[] memory, Simulation.Payload memory) internal view override {}
+
+    function _ownerSafe() internal view override returns (address) {
+        return OWNER_SAFE;
+    }
+}

--- a/active/evm/script/common/bridge/SetThreshold.s.sol
+++ b/active/evm/script/common/bridge/SetThreshold.s.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Vm} from "forge-std/Vm.sol";
+
+import {Simulation} from "@base-contracts/scripts/universal/Simulation.sol";
+import {MultisigScript, Enum} from "@base-contracts/scripts/universal/MultisigScript.sol";
+
+interface IOptimismPortal2 {
+    function depositTransaction(address _to, uint256 _value, uint64 _gasLimit, bool _isCreation, bytes memory _data)
+        external
+        payable;
+}
+
+interface IBridgeValidator {
+    function setPartnerThreshold(uint256 newThreshold) external;
+}
+
+contract SetThreshold is MultisigScript {
+    address public immutable OWNER_SAFE = vm.envAddress("OWNER_SAFE");
+    address public immutable L1_PORTAL = vm.envAddress("L1_PORTAL");
+    address public immutable L2_BRIDGE_VALIDATOR = vm.envAddress("L2_BRIDGE_VALIDATOR");
+    uint256 public immutable NEW_THRESHOLD = vm.envUint("NEW_THRESHOLD");
+
+    function _buildCalls() internal view override returns (Call[] memory) {
+        Call[] memory calls = new Call[](1);
+
+        address to = L2_BRIDGE_VALIDATOR;
+        uint256 value = 0;
+        uint64 gasLimit = 100_000;
+        bool isCreation = false;
+        bytes memory data = abi.encodeCall(IBridgeValidator.setPartnerThreshold, (NEW_THRESHOLD));
+
+        calls[0] = Call({
+            operation: Enum.Operation.Call,
+            target: L1_PORTAL,
+            data: abi.encodeCall(IOptimismPortal2.depositTransaction, (to, value, gasLimit, isCreation, data)),
+            value: value
+        });
+
+        return calls;
+    }
+
+    function _postCheck(Vm.AccountAccess[] memory, Simulation.Payload memory) internal view override {}
+
+    function _ownerSafe() internal view override returns (address) {
+        return OWNER_SAFE;
+    }
+}

--- a/active/evm/script/common/funding/Fund.s.sol
+++ b/active/evm/script/common/funding/Fund.s.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {Vm} from "forge-std/Vm.sol";
+
+import {MultisigScript, Enum} from "@base-contracts/scripts/universal/MultisigScript.sol";
+import {Simulation} from "@base-contracts/scripts/universal/Simulation.sol";
+
+contract FundScript is MultisigScript {
+    address internal immutable OWNER_SAFE;
+
+    uint256 internal immutable OWNER_SAFE_BALANCE_BEFORE;
+    uint256 internal immutable TOTAL_FUNDS;
+
+    address[] internal RECIPIENTS;
+    uint256[] internal FUNDS;
+    uint256[] internal RECIPIENT_BALANCES_BEFORE;
+
+    constructor() {
+        OWNER_SAFE = vm.envAddress("OWNER_SAFE");
+
+        string memory funding = vm.readFile("./funding.json");
+        RECIPIENTS = vm.parseJsonAddressArray(funding, ".recipients");
+        FUNDS = vm.parseJsonUintArray(funding, ".funds");
+
+        uint256 totalFunds = 0;
+        RECIPIENT_BALANCES_BEFORE = new uint256[](RECIPIENTS.length + 1);
+        for (uint256 i; i < RECIPIENTS.length; i++) {
+            RECIPIENT_BALANCES_BEFORE[i] = RECIPIENTS[i].balance;
+            totalFunds += FUNDS[i];
+        }
+
+        OWNER_SAFE_BALANCE_BEFORE = OWNER_SAFE.balance;
+        TOTAL_FUNDS = totalFunds;
+    }
+
+    function setUp() public view {
+        _precheck();
+    }
+
+    function _precheck() internal view {
+        require(RECIPIENTS.length == FUNDS.length, "RECIPIENTS and FUNDS not same length");
+        require(RECIPIENTS.length > 0, "RECIPIENTS and FUNDS empty");
+        require(OWNER_SAFE.balance >= TOTAL_FUNDS, "OWNER_SAFE not enough balance");
+    }
+
+    function _buildCalls() internal view override returns (Call[] memory) {
+        Call[] memory calls = new Call[](RECIPIENTS.length);
+
+        for (uint256 i; i < RECIPIENTS.length; i++) {
+            calls[i] = Call({operation: Enum.Operation.Call, target: RECIPIENTS[i], data: "", value: FUNDS[i]});
+        }
+
+        return calls;
+    }
+
+    function _postCheck(Vm.AccountAccess[] memory, Simulation.Payload memory) internal view override {
+        for (uint256 i; i < RECIPIENTS.length; i++) {
+            vm.assertEq(
+                RECIPIENTS[i].balance, RECIPIENT_BALANCES_BEFORE[i] + FUNDS[i], "Recipient balance is not correct"
+            );
+        }
+
+        vm.assertEq(OWNER_SAFE.balance, OWNER_SAFE_BALANCE_BEFORE - TOTAL_FUNDS, "Owner safe balance is not correct");
+    }
+
+    function _ownerSafe() internal view override returns (address) {
+        return OWNER_SAFE;
+    }
+}

--- a/active/evm/script/common/gas/IncreaseEip1559ElasticityAndIncreaseGasLimit.s.sol
+++ b/active/evm/script/common/gas/IncreaseEip1559ElasticityAndIncreaseGasLimit.s.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {Vm} from "forge-std/Vm.sol";
+
+import {Simulation} from "@base-contracts/scripts/universal/Simulation.sol";
+import {MultisigScript, Enum} from "@base-contracts/scripts/universal/MultisigScript.sol";
+
+interface ISystemConfig {
+    function eip1559Elasticity() external view returns (uint32);
+    function eip1559Denominator() external view returns (uint32);
+    function setEIP1559Params(uint32 _denominator, uint32 _elasticity) external;
+    function gasLimit() external view returns (uint64);
+    function setGasLimit(uint64 _gasLimit) external;
+    function daFootprintGasScalar() external view returns (uint16);
+    function setDAFootprintGasScalar(uint16 _daFootprintGasScalar) external;
+}
+
+contract IncreaseEip1559ElasticityAndIncreaseGasLimitScript is MultisigScript {
+    address internal immutable OWNER_SAFE;
+    address internal immutable SYSTEM_CONFIG;
+
+    uint32 internal immutable ELASTICITY;
+    uint32 internal immutable NEW_ELASTICITY;
+    uint64 internal immutable GAS_LIMIT;
+    uint64 internal immutable NEW_GAS_LIMIT;
+    uint32 internal immutable DENOMINATOR;
+    uint16 internal immutable DA_FOOTPRINT_GAS_SCALAR;
+    uint16 internal immutable NEW_DA_FOOTPRINT_GAS_SCALAR;
+
+    constructor() {
+        OWNER_SAFE = vm.envAddress("OWNER_SAFE");
+        SYSTEM_CONFIG = vm.envAddress("SYSTEM_CONFIG");
+
+        GAS_LIMIT = uint64(vm.envUint("OLD_GAS_LIMIT"));
+        NEW_GAS_LIMIT = uint64(vm.envUint("NEW_GAS_LIMIT"));
+
+        ELASTICITY = uint32(vm.envUint("OLD_ELASTICITY"));
+        NEW_ELASTICITY = uint32(vm.envUint("NEW_ELASTICITY"));
+
+        DA_FOOTPRINT_GAS_SCALAR = uint16(vm.envUint("OLD_DA_FOOTPRINT_GAS_SCALAR"));
+        NEW_DA_FOOTPRINT_GAS_SCALAR = uint16(vm.envUint("NEW_DA_FOOTPRINT_GAS_SCALAR"));
+
+        DENOMINATOR = ISystemConfig(SYSTEM_CONFIG).eip1559Denominator();
+    }
+
+    function _postCheck(Vm.AccountAccess[] memory, Simulation.Payload memory) internal view override {
+        vm.assertEq(ISystemConfig(SYSTEM_CONFIG).eip1559Denominator(), DENOMINATOR, "Denominator mismatch");
+        vm.assertEq(ISystemConfig(SYSTEM_CONFIG).eip1559Elasticity(), NEW_ELASTICITY, "Elasticity mismatch");
+        vm.assertEq(ISystemConfig(SYSTEM_CONFIG).gasLimit(), NEW_GAS_LIMIT, "Gas Limit mismatch");
+        vm.assertEq(
+            ISystemConfig(SYSTEM_CONFIG).daFootprintGasScalar(),
+            NEW_DA_FOOTPRINT_GAS_SCALAR,
+            "DA Footprint Gas Scalar mismatch"
+        );
+    }
+
+    function _simulationOverrides() internal view override returns (Simulation.StateOverride[] memory _stateOverrides) {
+        if (
+            GAS_LIMIT != ISystemConfig(SYSTEM_CONFIG).gasLimit()
+                || ELASTICITY != ISystemConfig(SYSTEM_CONFIG).eip1559Elasticity()
+                || DA_FOOTPRINT_GAS_SCALAR != ISystemConfig(SYSTEM_CONFIG).daFootprintGasScalar()
+        ) {
+            // Override SystemConfig state to the expected "from" values so simulations succeeds even
+            // when the chain already reflects the post-change values (during rollback simulation).
+
+            // Prepare two storage overrides for SystemConfig
+            Simulation.StateOverride[] memory stateOverrides = new Simulation.StateOverride[](1);
+            Simulation.StorageOverride[] memory storageOverrides = new Simulation.StorageOverride[](2);
+
+            // Load current packed gas config (slot 0x68) and replace only the lower 64 bits with GAS_LIMIT
+            bytes32 gasConfigSlotKey = bytes32(uint256(0x68));
+            uint256 gasConfigWord = uint256(vm.load(SYSTEM_CONFIG, gasConfigSlotKey));
+            uint256 updatedGasConfigWord = (gasConfigWord & ~uint256(0xffffffffffffffff)) | uint256(GAS_LIMIT);
+            storageOverrides[0] =
+                Simulation.StorageOverride({key: gasConfigSlotKey, value: bytes32(updatedGasConfigWord)});
+
+            // Update EIP-1559 params and DA Footprint Gas Scalar (slot 0x6a)
+            // Storage layout (low to high bits):
+            //   - eip1559Denominator (uint32): bits 0-31
+            //   - eip1559Elasticity (uint32): bits 32-63
+            //   - operatorFeeScalar (uint32): bits 64-95
+            //   - operatorFeeConstant (uint64): bits 96-159
+            //   - daFootprintGasScalar (uint16): bits 160-175
+            // Load existing slot to preserve operatorFeeScalar and operatorFeeConstant, then update
+            // the fields we care about.
+            bytes32 eip1559SlotKey = bytes32(uint256(0x6a));
+            uint256 existingEip1559Word = uint256(vm.load(SYSTEM_CONFIG, eip1559SlotKey));
+            // Mask to preserve bits 64-159 (operatorFeeScalar and operatorFeeConstant)
+            uint256 operatorFeeMask = uint256(0xFFFFFFFFFFFFFFFFFFFFFFFF) << 64;
+            uint256 preservedOperatorFees = existingEip1559Word & operatorFeeMask;
+            uint256 composedEip1559Word = (uint256(DA_FOOTPRINT_GAS_SCALAR) << 160) | preservedOperatorFees
+                | (uint256(ELASTICITY) << 32) | uint256(DENOMINATOR);
+            storageOverrides[1] = Simulation.StorageOverride({key: eip1559SlotKey, value: bytes32(composedEip1559Word)});
+
+            stateOverrides[0] = Simulation.StateOverride({contractAddress: SYSTEM_CONFIG, overrides: storageOverrides});
+            return stateOverrides;
+        }
+    }
+
+    function _buildCalls() internal view override returns (Call[] memory) {
+        Call[] memory calls = new Call[](3);
+
+        calls[0] = Call({
+            operation: Enum.Operation.Call,
+            target: SYSTEM_CONFIG,
+            data: abi.encodeCall(ISystemConfig.setEIP1559Params, (DENOMINATOR, NEW_ELASTICITY)),
+            value: 0
+        });
+
+        calls[1] = Call({
+            operation: Enum.Operation.Call,
+            target: SYSTEM_CONFIG,
+            data: abi.encodeCall(ISystemConfig.setGasLimit, (NEW_GAS_LIMIT)),
+            value: 0
+        });
+
+        calls[2] = Call({
+            operation: Enum.Operation.Call,
+            target: SYSTEM_CONFIG,
+            data: abi.encodeCall(ISystemConfig.setDAFootprintGasScalar, (NEW_DA_FOOTPRINT_GAS_SCALAR)),
+            value: 0
+        });
+
+        return calls;
+    }
+
+    function _ownerSafe() internal view override returns (address) {
+        return OWNER_SAFE;
+    }
+}

--- a/active/evm/script/common/ownership/TransferSystemConfigOwnership.s.sol
+++ b/active/evm/script/common/ownership/TransferSystemConfigOwnership.s.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {Vm} from "forge-std/Vm.sol";
+
+import {Simulation} from "@base-contracts/scripts/universal/Simulation.sol";
+import {MultisigScript, Enum} from "@base-contracts/scripts/universal/MultisigScript.sol";
+
+interface IOwnable {
+    function owner() external view returns (address);
+    function transferOwnership(address newOwner) external;
+}
+
+contract TransferSystemConfigOwnership is MultisigScript {
+    address internal immutable PROXY_ADMIN_OWNER;
+    address internal immutable INCIDENT_MULTISIG;
+    address internal immutable SYSTEM_CONFIG;
+
+    constructor() {
+        PROXY_ADMIN_OWNER = vm.envAddress("PROXY_ADMIN_OWNER");
+        INCIDENT_MULTISIG = vm.envAddress("INCIDENT_MULTISIG");
+        SYSTEM_CONFIG = vm.envAddress("SYSTEM_CONFIG");
+
+        require(IOwnable(SYSTEM_CONFIG).owner() == PROXY_ADMIN_OWNER, "current owner mismatch");
+    }
+
+    function _postCheck(Vm.AccountAccess[] memory, Simulation.Payload memory) internal view override {
+        require(IOwnable(SYSTEM_CONFIG).owner() == INCIDENT_MULTISIG, "new owner mismatch");
+    }
+
+    function _buildCalls() internal view override returns (Call[] memory) {
+        Call[] memory calls = new Call[](1);
+
+        calls[0] = Call({
+            operation: Enum.Operation.Call,
+            target: SYSTEM_CONFIG,
+            data: abi.encodeCall(IOwnable.transferOwnership, (INCIDENT_MULTISIG)),
+            value: 0
+        });
+
+        return calls;
+    }
+
+    function _ownerSafe() internal view override returns (address) {
+        return PROXY_ADMIN_OWNER;
+    }
+}

--- a/active/evm/script/common/safe/UpdateSigners.s.sol
+++ b/active/evm/script/common/safe/UpdateSigners.s.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {Vm} from "forge-std/Vm.sol";
+import {stdJson} from "forge-std/StdJson.sol";
+import {Simulation} from "@base-contracts/scripts/universal/Simulation.sol";
+
+import {MultisigScript, Enum} from "@base-contracts/scripts/universal/MultisigScript.sol";
+
+interface IGnosisSafeOwners {
+    function getThreshold() external view returns (uint256);
+    function getOwners() external view returns (address[] memory);
+    function isOwner(address owner) external view returns (bool);
+}
+
+interface IOwnerManager {
+    function addOwnerWithThreshold(address owner, uint256 threshold) external;
+    function removeOwner(address prevOwner, address owner, uint256 threshold) external;
+}
+
+contract UpdateSigners is MultisigScript {
+    using stdJson for string;
+
+    address public constant SENTINEL_OWNERS = address(0x1);
+
+    address public immutable OWNER_SAFE;
+    uint256 public immutable THRESHOLD;
+    address[] public EXISTING_OWNERS;
+
+    address[] public OWNERS_TO_ADD;
+    address[] public OWNERS_TO_REMOVE;
+
+    mapping(address => address) public ownerToPrevOwner;
+    mapping(address => address) public ownerToNextOwner;
+    mapping(address => bool) public expectedOwner;
+
+    constructor() {
+        OWNER_SAFE = vm.envAddress("OWNER_SAFE");
+
+        IGnosisSafeOwners ownerSafe = IGnosisSafeOwners(OWNER_SAFE);
+        THRESHOLD = ownerSafe.getThreshold();
+        EXISTING_OWNERS = ownerSafe.getOwners();
+
+        string memory rootPath = vm.projectRoot();
+        string memory path = string.concat(rootPath, "/OwnerDiff.json");
+        string memory jsonData = vm.readFile(path);
+
+        OWNERS_TO_ADD = abi.decode(jsonData.parseRaw(".OwnersToAdd"), (address[]));
+        OWNERS_TO_REMOVE = abi.decode(jsonData.parseRaw(".OwnersToRemove"), (address[]));
+    }
+
+    function setUp() external {
+        require(OWNERS_TO_ADD.length > 0, "Precheck 00");
+        require(OWNERS_TO_REMOVE.length > 0, "Precheck 01");
+
+        IGnosisSafeOwners ownerSafe = IGnosisSafeOwners(OWNER_SAFE);
+        address prevOwner = SENTINEL_OWNERS;
+
+        for (uint256 i = OWNERS_TO_ADD.length; i > 0; i--) {
+            uint256 index = i - 1;
+            // Make sure owners to add are not already owners
+            require(!ownerSafe.isOwner(OWNERS_TO_ADD[index]), "Precheck 03");
+            // Prevent duplicates
+            require(!expectedOwner[OWNERS_TO_ADD[index]], "Precheck 04");
+
+            ownerToPrevOwner[OWNERS_TO_ADD[index]] = prevOwner;
+            ownerToNextOwner[prevOwner] = OWNERS_TO_ADD[index];
+            prevOwner = OWNERS_TO_ADD[index];
+            expectedOwner[OWNERS_TO_ADD[index]] = true;
+        }
+
+        for (uint256 i; i < EXISTING_OWNERS.length; i++) {
+            ownerToPrevOwner[EXISTING_OWNERS[i]] = prevOwner;
+            ownerToNextOwner[prevOwner] = EXISTING_OWNERS[i];
+            prevOwner = EXISTING_OWNERS[i];
+            expectedOwner[EXISTING_OWNERS[i]] = true;
+        }
+
+        for (uint256 i; i < OWNERS_TO_REMOVE.length; i++) {
+            // Make sure owners to remove are owners
+            require(ownerSafe.isOwner(OWNERS_TO_REMOVE[i]), "Precheck 05");
+            // Prevent duplicates
+            require(expectedOwner[OWNERS_TO_REMOVE[i]], "Precheck 06");
+            expectedOwner[OWNERS_TO_REMOVE[i]] = false;
+
+            // Remove from linked list to keep ownerToPrevOwner up to date
+            // Note: This works as long as the order of OWNERS_TO_REMOVE does not change during `_buildCalls()`
+            address nextOwner = ownerToNextOwner[OWNERS_TO_REMOVE[i]];
+            address prevPtr = ownerToPrevOwner[OWNERS_TO_REMOVE[i]];
+            ownerToPrevOwner[nextOwner] = prevPtr;
+            ownerToNextOwner[prevPtr] = nextOwner;
+        }
+    }
+
+    function _postCheck(Vm.AccountAccess[] memory, Simulation.Payload memory) internal view override {
+        IGnosisSafeOwners ownerSafe = IGnosisSafeOwners(OWNER_SAFE);
+        address[] memory postCheckOwners = ownerSafe.getOwners();
+        uint256 postCheckThreshold = ownerSafe.getThreshold();
+
+        uint256 expectedLength = EXISTING_OWNERS.length + OWNERS_TO_ADD.length - OWNERS_TO_REMOVE.length;
+
+        require(postCheckThreshold == THRESHOLD, "Postcheck 00");
+        require(postCheckOwners.length == expectedLength, "Postcheck 01");
+
+        for (uint256 i; i < postCheckOwners.length; i++) {
+            require(expectedOwner[postCheckOwners[i]], "Postcheck 02");
+        }
+    }
+
+    function _buildCalls() internal view override returns (Call[] memory) {
+        Call[] memory calls = new Call[](OWNERS_TO_ADD.length + OWNERS_TO_REMOVE.length);
+
+        for (uint256 i; i < OWNERS_TO_ADD.length; i++) {
+            calls[i] = Call({
+                operation: Enum.Operation.Call,
+                target: OWNER_SAFE,
+                data: abi.encodeCall(IOwnerManager.addOwnerWithThreshold, (OWNERS_TO_ADD[i], THRESHOLD)),
+                value: 0
+            });
+        }
+
+        for (uint256 i; i < OWNERS_TO_REMOVE.length; i++) {
+            calls[OWNERS_TO_ADD.length + i] = Call({
+                operation: Enum.Operation.Call,
+                target: OWNER_SAFE,
+                data: abi.encodeCall(
+                    IOwnerManager.removeOwner, (ownerToPrevOwner[OWNERS_TO_REMOVE[i]], OWNERS_TO_REMOVE[i], THRESHOLD)
+                ),
+                value: 0
+            });
+        }
+
+        return calls;
+    }
+
+    function _ownerSafe() internal view override returns (address) {
+        return OWNER_SAFE;
+    }
+}

--- a/active/evm/script/common/superchain/PauseSuperchainConfig.s.sol
+++ b/active/evm/script/common/superchain/PauseSuperchainConfig.s.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {Vm} from "forge-std/Vm.sol";
+import {Simulation} from "@base-contracts/scripts/universal/Simulation.sol";
+import {MultisigScript, Enum} from "@base-contracts/scripts/universal/MultisigScript.sol";
+
+interface ISystemConfig {
+    function superchainConfig() external view returns (address);
+}
+
+interface ISuperchainConfig {
+    function pause(address _identifier) external;
+    function paused(address) external view returns (bool);
+}
+
+contract PauseSuperchainConfig is MultisigScript {
+    address public immutable INCIDENT_MULTISIG = vm.envAddress("INCIDENT_MULTISIG");
+    address public immutable SYSTEM_CONFIG = vm.envAddress("SYSTEM_CONFIG");
+
+    function _buildCalls() internal view override returns (Call[] memory) {
+        Call[] memory calls = new Call[](1);
+
+        address superchainConfig = ISystemConfig(SYSTEM_CONFIG).superchainConfig();
+
+        calls[0] = Call({
+            operation: Enum.Operation.Call,
+            target: superchainConfig,
+            data: abi.encodeCall(ISuperchainConfig.pause, (address(0))),
+            value: 0
+        });
+
+        return calls;
+    }
+
+    function _postCheck(Vm.AccountAccess[] memory, Simulation.Payload memory) internal view override {
+        address superchainConfig = ISystemConfig(SYSTEM_CONFIG).superchainConfig();
+        bool paused = ISuperchainConfig(superchainConfig).paused(address(0));
+        require(paused == true, "PauseSuperchainConfig: chain is not paused");
+    }
+
+    function _ownerSafe() internal view override returns (address) {
+        return INCIDENT_MULTISIG;
+    }
+}

--- a/active/evm/script/common/verifier-update/DeployAggregateVerifier.s.sol
+++ b/active/evm/script/common/verifier-update/DeployAggregateVerifier.s.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {Script, console} from "forge-std/Script.sol";
+
+import {IAnchorStateRegistry} from "interfaces/L1/proofs/IAnchorStateRegistry.sol";
+import {IDelayedWETH} from "interfaces/L1/proofs/IDelayedWETH.sol";
+import {IDisputeGameFactory} from "interfaces/L1/proofs/IDisputeGameFactory.sol";
+import {IVerifier} from "interfaces/L1/proofs/IVerifier.sol";
+
+import {AggregateVerifier} from "@base-contracts/src/L1/proofs/AggregateVerifier.sol";
+import {GameType} from "@base-contracts/src/libraries/bridge/Types.sol";
+
+/// @notice Redeploys AggregateVerifier with updated TEE_IMAGE_HASH, ZK_RANGE_HASH,
+/// and ZK_AGGREGATE_HASH. All other immutables are read from the current
+/// onchain AggregateVerifier to guarantee continuity.
+contract DeployAggregateVerifier is Script {
+    // Task config from .env.
+    address internal immutable disputeGameFactoryProxyEnv;
+    GameType internal immutable gameTypeEnv;
+    bytes32 internal immutable teeImageHashEnv;
+    bytes32 internal immutable zkRangeHashEnv;
+    bytes32 internal immutable zkAggregateHashEnv;
+
+    // Live multiproof implementation currently registered in the DGF.
+    address internal immutable currentAggregateVerifier;
+
+    // Constructor args copied from the live AggregateVerifier.
+    GameType internal immutable currentGameType;
+    IAnchorStateRegistry internal immutable currentAnchorStateRegistry;
+    IDelayedWETH internal immutable currentDelayedWeth;
+    address internal immutable currentTeeVerifier;
+    address internal immutable currentZkVerifier;
+    bytes32 internal immutable currentConfigHash;
+    uint256 internal immutable currentL2ChainId;
+    uint256 internal immutable currentBlockInterval;
+    uint256 internal immutable currentIntermediateBlockInterval;
+
+    // Deployment output written to addresses.json.
+    address public aggregateVerifier;
+
+    constructor() {
+        disputeGameFactoryProxyEnv = vm.envAddress("DISPUTE_GAME_FACTORY_PROXY");
+        gameTypeEnv = GameType.wrap(uint32(vm.envUint("GAME_TYPE")));
+        teeImageHashEnv = vm.envBytes32("TEE_IMAGE_HASH");
+        zkRangeHashEnv = vm.envBytes32("ZK_RANGE_HASH");
+        zkAggregateHashEnv = vm.envBytes32("ZK_AGGREGATE_HASH");
+
+        currentAggregateVerifier = address(IDisputeGameFactory(disputeGameFactoryProxyEnv).gameImpls(gameTypeEnv));
+
+        AggregateVerifier currentAggregate = AggregateVerifier(currentAggregateVerifier);
+        currentGameType = currentAggregate.gameType();
+        currentAnchorStateRegistry = currentAggregate.anchorStateRegistry();
+        currentDelayedWeth = currentAggregate.DELAYED_WETH();
+        currentTeeVerifier = address(currentAggregate.TEE_VERIFIER());
+        currentZkVerifier = address(currentAggregate.ZK_VERIFIER());
+        currentConfigHash = currentAggregate.CONFIG_HASH();
+        currentL2ChainId = currentAggregate.L2_CHAIN_ID();
+        currentBlockInterval = currentAggregate.BLOCK_INTERVAL();
+        currentIntermediateBlockInterval = currentAggregate.INTERMEDIATE_BLOCK_INTERVAL();
+    }
+
+    function setUp() public view {
+        require(currentAggregateVerifier != address(0), "current aggregate verifier not found");
+        require(GameType.unwrap(currentGameType) == GameType.unwrap(gameTypeEnv), "current game type mismatch");
+        require(currentTeeVerifier != address(0), "current tee verifier not found");
+        require(currentZkVerifier != address(0), "current zk verifier not found");
+        require(teeImageHashEnv != bytes32(0), "tee image hash not set");
+        require(zkRangeHashEnv != bytes32(0), "zk range hash not set");
+        require(zkAggregateHashEnv != bytes32(0), "zk aggregate hash not set");
+
+        AggregateVerifier currentAggregate = AggregateVerifier(currentAggregateVerifier);
+        require(
+            teeImageHashEnv != currentAggregate.TEE_IMAGE_HASH() || zkRangeHashEnv != currentAggregate.ZK_RANGE_HASH()
+                || zkAggregateHashEnv != currentAggregate.ZK_AGGREGATE_HASH(),
+            "all hashes are identical to the current aggregate verifier"
+        );
+    }
+
+    function run() external {
+        vm.startBroadcast();
+
+        aggregateVerifier = address(
+            new AggregateVerifier({
+                gameType_: currentGameType,
+                anchorStateRegistry_: currentAnchorStateRegistry,
+                delayedWETH: currentDelayedWeth,
+                teeVerifier: IVerifier(currentTeeVerifier),
+                zkVerifier: IVerifier(currentZkVerifier),
+                teeImageHash: teeImageHashEnv,
+                zkHashes: AggregateVerifier.ZkHashes({rangeHash: zkRangeHashEnv, aggregateHash: zkAggregateHashEnv}),
+                configHash: currentConfigHash,
+                l2ChainId: currentL2ChainId,
+                blockInterval: currentBlockInterval,
+                intermediateBlockInterval: currentIntermediateBlockInterval
+            })
+        );
+
+        vm.stopBroadcast();
+
+        _postCheck();
+        _writeAddresses();
+    }
+
+    function _postCheck() internal view {
+        AggregateVerifier currentAggregate = AggregateVerifier(currentAggregateVerifier);
+        AggregateVerifier av = AggregateVerifier(aggregateVerifier);
+
+        require(av.TEE_IMAGE_HASH() == teeImageHashEnv, "aggregate tee image hash mismatch");
+        require(av.ZK_RANGE_HASH() == zkRangeHashEnv, "aggregate zk range hash mismatch");
+        require(av.ZK_AGGREGATE_HASH() == zkAggregateHashEnv, "aggregate zk aggregate hash mismatch");
+
+        require(GameType.unwrap(av.gameType()) == GameType.unwrap(currentGameType), "aggregate game type mismatch");
+        require(address(av.anchorStateRegistry()) == address(currentAnchorStateRegistry), "aggregate asr mismatch");
+        require(
+            address(av.DISPUTE_GAME_FACTORY()) == address(currentAggregate.DISPUTE_GAME_FACTORY()),
+            "aggregate dgf mismatch"
+        );
+        require(address(av.DELAYED_WETH()) == address(currentDelayedWeth), "aggregate delayed weth mismatch");
+        require(address(av.TEE_VERIFIER()) == currentTeeVerifier, "aggregate tee verifier mismatch");
+        require(address(av.ZK_VERIFIER()) == currentZkVerifier, "aggregate zk verifier mismatch");
+        require(av.CONFIG_HASH() == currentConfigHash, "aggregate config hash mismatch");
+        require(av.L2_CHAIN_ID() == currentL2ChainId, "aggregate l2 chain id mismatch");
+        require(av.BLOCK_INTERVAL() == currentBlockInterval, "aggregate block interval mismatch");
+        require(
+            av.INTERMEDIATE_BLOCK_INTERVAL() == currentIntermediateBlockInterval,
+            "aggregate intermediate interval mismatch"
+        );
+    }
+
+    function _writeAddresses() internal {
+        console.log("AggregateVerifier:", aggregateVerifier);
+
+        string memory root = "root";
+        string memory json =
+            vm.serializeAddress({objectKey: root, valueKey: "aggregateVerifier", value: aggregateVerifier});
+        string memory path = vm.envOr("ADDRESSES_JSON", string("addresses.json"));
+        vm.writeJson({json: json, path: path});
+    }
+}

--- a/active/evm/script/common/verifier-update/UpdateVerifierHashes.s.sol
+++ b/active/evm/script/common/verifier-update/UpdateVerifierHashes.s.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {Vm} from "forge-std/Vm.sol";
+
+import {MultisigScript, Enum} from "@base-contracts/scripts/universal/MultisigScript.sol";
+import {Simulation} from "@base-contracts/scripts/universal/Simulation.sol";
+import {AggregateVerifier} from "@base-contracts/src/L1/proofs/AggregateVerifier.sol";
+import {GameType} from "@base-contracts/src/libraries/bridge/Types.sol";
+
+interface IDisputeGameFactoryAdmin {
+    function owner() external view returns (address);
+    function gameImpls(GameType gameType) external view returns (address);
+    function setImplementation(GameType gameType, address impl, bytes calldata args) external;
+}
+
+/// @notice Updates the live multiproof implementation in the DisputeGameFactory to
+/// the newly deployed AggregateVerifier carrying updated TEE_IMAGE_HASH,
+/// ZK_RANGE_HASH, and ZK_AGGREGATE_HASH.
+contract UpdateVerifierHashes is MultisigScript {
+    // Task config from .env.
+    address internal immutable ownerSafeEnv;
+    address internal immutable disputeGameFactoryProxyEnv;
+    GameType internal immutable gameTypeEnv;
+    bytes32 internal immutable teeImageHashEnv;
+    bytes32 internal immutable zkRangeHashEnv;
+    bytes32 internal immutable zkAggregateHashEnv;
+
+    // Live onchain state.
+    address internal immutable currentAggregateVerifier;
+
+    // Deployment output produced by the EOA script and read from addresses.json.
+    address internal immutable nextAggregateVerifier;
+    GameType internal immutable nextGameType;
+
+    constructor() {
+        ownerSafeEnv = vm.envAddress("PROXY_ADMIN_OWNER");
+        disputeGameFactoryProxyEnv = vm.envAddress("DISPUTE_GAME_FACTORY_PROXY");
+        gameTypeEnv = GameType.wrap(uint32(vm.envUint("GAME_TYPE")));
+        teeImageHashEnv = vm.envBytes32("TEE_IMAGE_HASH");
+        zkRangeHashEnv = vm.envBytes32("ZK_RANGE_HASH");
+        zkAggregateHashEnv = vm.envBytes32("ZK_AGGREGATE_HASH");
+
+        currentAggregateVerifier = IDisputeGameFactoryAdmin(disputeGameFactoryProxyEnv).gameImpls(gameTypeEnv);
+
+        string memory path = vm.envOr("ADDRESSES_JSON", string("addresses.json"));
+        string memory json = vm.readFile(path);
+        nextAggregateVerifier = vm.parseJsonAddress({json: json, key: ".aggregateVerifier"});
+
+        nextGameType = AggregateVerifier(nextAggregateVerifier).gameType();
+    }
+
+    function setUp() public view {
+        require(IDisputeGameFactoryAdmin(disputeGameFactoryProxyEnv).owner() == ownerSafeEnv, "dgf owner mismatch");
+        require(currentAggregateVerifier != address(0), "current aggregate verifier not found");
+        require(nextAggregateVerifier != address(0), "next aggregate verifier not set");
+        require(nextAggregateVerifier != currentAggregateVerifier, "next aggregate verifier equals current");
+        require(teeImageHashEnv != bytes32(0), "tee image hash not set");
+        require(zkRangeHashEnv != bytes32(0), "zk range hash not set");
+        require(zkAggregateHashEnv != bytes32(0), "zk aggregate hash not set");
+
+        AggregateVerifier currentAggregate = AggregateVerifier(currentAggregateVerifier);
+        AggregateVerifier nextAggregate = AggregateVerifier(nextAggregateVerifier);
+
+        require(
+            GameType.unwrap(currentAggregate.gameType()) == GameType.unwrap(gameTypeEnv), "current game type mismatch"
+        );
+        require(GameType.unwrap(nextGameType) == GameType.unwrap(gameTypeEnv), "next game type mismatch");
+
+        _assertUpdatedHashes(nextAggregate);
+        _assertImmutableContinuity(currentAggregate, nextAggregate);
+    }
+
+    function _buildCalls() internal view override returns (Call[] memory) {
+        Call[] memory calls = new Call[](1);
+
+        calls[0] = Call({
+            operation: Enum.Operation.Call,
+            target: disputeGameFactoryProxyEnv,
+            data: abi.encodeCall(IDisputeGameFactoryAdmin.setImplementation, (nextGameType, nextAggregateVerifier, "")),
+            value: 0
+        });
+
+        return calls;
+    }
+
+    function _postCheck(Vm.AccountAccess[] memory, Simulation.Payload memory) internal view override {
+        IDisputeGameFactoryAdmin dgf = IDisputeGameFactoryAdmin(disputeGameFactoryProxyEnv);
+        AggregateVerifier currentAggregate = AggregateVerifier(currentAggregateVerifier);
+        AggregateVerifier nextAggregate = AggregateVerifier(nextAggregateVerifier);
+
+        require(dgf.gameImpls(nextGameType) == nextAggregateVerifier, "dgf aggregate verifier mismatch");
+
+        _assertUpdatedHashes(nextAggregate);
+        _assertImmutableContinuity(currentAggregate, nextAggregate);
+    }
+
+    function _assertUpdatedHashes(AggregateVerifier nextAggregate) internal view {
+        require(nextAggregate.TEE_IMAGE_HASH() == teeImageHashEnv, "next aggregate tee image hash mismatch");
+        require(nextAggregate.ZK_RANGE_HASH() == zkRangeHashEnv, "next aggregate zk range hash mismatch");
+        require(nextAggregate.ZK_AGGREGATE_HASH() == zkAggregateHashEnv, "next aggregate zk aggregate hash mismatch");
+    }
+
+    function _assertImmutableContinuity(AggregateVerifier currentAggregate, AggregateVerifier nextAggregate)
+        internal
+        view
+    {
+        require(
+            address(nextAggregate.anchorStateRegistry()) == address(currentAggregate.anchorStateRegistry()),
+            "next aggregate asr mismatch"
+        );
+        require(
+            address(nextAggregate.DISPUTE_GAME_FACTORY()) == address(currentAggregate.DISPUTE_GAME_FACTORY()),
+            "next aggregate dgf mismatch"
+        );
+        require(
+            address(nextAggregate.DELAYED_WETH()) == address(currentAggregate.DELAYED_WETH()),
+            "next aggregate delayed weth mismatch"
+        );
+        require(
+            address(nextAggregate.TEE_VERIFIER()) == address(currentAggregate.TEE_VERIFIER()),
+            "next aggregate tee verifier mismatch"
+        );
+        require(
+            address(nextAggregate.ZK_VERIFIER()) == address(currentAggregate.ZK_VERIFIER()),
+            "next aggregate zk verifier mismatch"
+        );
+        require(nextAggregate.CONFIG_HASH() == currentAggregate.CONFIG_HASH(), "next aggregate config hash mismatch");
+        require(nextAggregate.L2_CHAIN_ID() == currentAggregate.L2_CHAIN_ID(), "next aggregate l2 chain id mismatch");
+        require(
+            nextAggregate.BLOCK_INTERVAL() == currentAggregate.BLOCK_INTERVAL(),
+            "next aggregate block interval mismatch"
+        );
+        require(
+            nextAggregate.INTERMEDIATE_BLOCK_INTERVAL() == currentAggregate.INTERMEDIATE_BLOCK_INTERVAL(),
+            "next aggregate intermediate interval mismatch"
+        );
+    }
+
+    function _ownerSafe() internal view override returns (address) {
+        return ownerSafeEnv;
+    }
+}


### PR DESCRIPTION
## What changed?

Bootstraps the `active/evm` shared Foundry project (on base-contracts v8.2.1) and adds the reusable `script/common/` library used across active EVM tasks:

- Root `Makefile` / `Multisig.mk`: generic `PROJECT_DIR` support, `TASK_ORIGIN_DIR` for task-origin signing, signer-tool pinned to the latest `566102`.
- `active/evm/foundry.toml`: shared project config (prague, auto-detect solc, base-contracts remappings).
- `active/evm/script/common/{bridge,funding,gas,ownership,safe,superchain,verifier-update}`: reusable operation scripts + inventory README.
- `active/evm/tasks/.gitkeep`: establishes the (empty) tasks directory.

No task-specific files are included — each task supplies its own Makefile and config under `active/evm/tasks/<task-id>/`.

## Why?

Replaces the old per-task standalone Foundry projects (`setup-templates/template-*`) with one shared project + reusable scripts, so multiple active tasks share the same audited `script/common` implementations. Foundation for the stacked CI, docs, and task PRs.

## How to test?

```bash
cd active/evm
make deps                        # installs lib/ into active/evm at v8.2.1
mise exec -- forge build         # all script/common compiles
mise exec -- forge fmt --check script/
```
All three should pass (build compiles 0.8.15 + 0.8.28 sources; fmt clean).